### PR TITLE
UIActivityItemProvider Subclass

### DIFF
--- a/Branch-SDK/Branch-SDK/Branch.h
+++ b/Branch-SDK/Branch-SDK/Branch.h
@@ -62,31 +62,9 @@ typedef enum {
                                                   andFeature:(NSString *)feature;
 
 + (BranchActivityItemProvider *)getBranchActivityItemWithDefaultURL:(NSString *)url
-                                                          andParams:(NSDictionary *)params
-                                                         andStage:(NSString *)stage;
-
-+ (BranchActivityItemProvider *)getBranchActivityItemWithDefaultURL:(NSString *)url
-                                                          andParams:(NSDictionary *)params
-                                                         andAlias:(NSString *)alias;
-
-+ (BranchActivityItemProvider *)getBranchActivityItemWithDefaultURL:(NSString *)url
-                                                          andParams:(NSDictionary *)params
-                                                            andTags:(NSArray *)tags;
-
-+ (BranchActivityItemProvider *)getBranchActivityItemWithDefaultURL:(NSString *)url
                                                    andParams:(NSDictionary *)params
                                                   andFeature:(NSString *)feature
                                                     andStage:(NSString *)stage;
-
-+ (BranchActivityItemProvider *)getBranchActivityItemWithDefaultURL:(NSString *)url
-                                                          andParams:(NSDictionary *)params
-                                                            andAlias:(NSString *)alias
-                                                            andTags:(NSArray *)tags;
-
-+ (BranchActivityItemProvider *)getBranchActivityItemWithDefaultURL:(NSString *)url
-                                                          andParams:(NSDictionary *)params
-                                                         andFeature:(NSString *)feature
-                                                           andAlias:(NSString *)alias;
 
 + (BranchActivityItemProvider *)getBranchActivityItemWithDefaultURL:(NSString *)url
                                                           andParams:(NSDictionary *)params
@@ -96,18 +74,6 @@ typedef enum {
 + (BranchActivityItemProvider *)getBranchActivityItemWithDefaultURL:(NSString *)url
                                                           andParams:(NSDictionary *)params
                                                          andFeature:(NSString *)feature
-                                                           andStage:(NSString *)stage
-                                                           andAlias:(NSString *)alias;
-
-+ (BranchActivityItemProvider *)getBranchActivityItemWithDefaultURL:(NSString *)url
-                                                          andParams:(NSDictionary *)params
-                                                            andTags:(NSArray *)tags
-                                                         andFeature:(NSString *)feature
-                                                           andStage:(NSString *)stage;
-
-+ (BranchActivityItemProvider *)getBranchActivityItemWithDefaultURL:(NSString *)url
-                                                          andParams:(NSDictionary *)params
-                                                            andTags:(NSArray *)tags
                                                            andStage:(NSString *)stage
                                                            andAlias:(NSString *)alias;
 

--- a/Branch-SDK/Branch-SDK/Branch.m
+++ b/Branch-SDK/Branch-SDK/Branch.m
@@ -152,27 +152,6 @@ static Branch *currInstance;
 
 + (BranchActivityItemProvider *)getBranchActivityItemWithDefaultURL:(NSString *)url
                                                           andParams:(NSDictionary *)params
-                                                           andStage:(NSString *)stage  {
-    
-    return [[BranchActivityItemProvider alloc] initWithDefaultURL:url andParams:params andTags:nil andFeature:nil andStage:stage andAlias:nil];
-}
-
-+ (BranchActivityItemProvider *)getBranchActivityItemWithDefaultURL:(NSString *)url
-                                                          andParams:(NSDictionary *)params
-                                                           andAlias:(NSString *)alias {
-    
-    return [[BranchActivityItemProvider alloc] initWithDefaultURL:url andParams:params andTags:nil andFeature:nil andStage:nil andAlias:alias];
-}
-
-+ (BranchActivityItemProvider *)getBranchActivityItemWithDefaultURL:(NSString *)url
-                                                          andParams:(NSDictionary *)params
-                                                            andTags:(NSArray *)tags {
-    
-    return [[BranchActivityItemProvider alloc] initWithDefaultURL:url andParams:params andTags:tags andFeature:nil andStage:nil andAlias:nil];
-}
-
-+ (BranchActivityItemProvider *)getBranchActivityItemWithDefaultURL:(NSString *)url
-                                                          andParams:(NSDictionary *)params
                                                          andFeature:(NSString *)feature
                                                            andStage:(NSString *)stage {
     
@@ -181,44 +160,10 @@ static Branch *currInstance;
 
 + (BranchActivityItemProvider *)getBranchActivityItemWithDefaultURL:(NSString *)url
                                                           andParams:(NSDictionary *)params
-                                                           andAlias:(NSString *)alias
-                                                            andTags:(NSArray *)tags {
-    
-    return [[BranchActivityItemProvider alloc] initWithDefaultURL:url andParams:params andTags:tags andFeature:nil andStage:nil andAlias:alias];
-}
-
-+ (BranchActivityItemProvider *)getBranchActivityItemWithDefaultURL:(NSString *)url
-                                                          andParams:(NSDictionary *)params
-                                                         andFeature:(NSString *)feature
-                                                           andAlias:(NSString *)alias {
-    
-    return [[BranchActivityItemProvider alloc] initWithDefaultURL:url andParams:params andTags:nil andFeature:feature andStage:nil andAlias:alias];
-}
-
-+ (BranchActivityItemProvider *)getBranchActivityItemWithDefaultURL:(NSString *)url
-                                                          andParams:(NSDictionary *)params
                                                          andFeature:(NSString *)feature
                                                             andTags:(NSArray *)tags {
     
     return [[BranchActivityItemProvider alloc] initWithDefaultURL:url andParams:params andTags:tags andFeature:feature andStage:nil andAlias:nil];
-}
-
-+ (BranchActivityItemProvider *)getBranchActivityItemWithDefaultURL:(NSString *)url
-                                                          andParams:(NSDictionary *)params
-                                                         andFeature:(NSString *)feature
-                                                           andStage:(NSString *)stage
-                                                           andAlias:(NSString *)alias {
-    
-    return [[BranchActivityItemProvider alloc] initWithDefaultURL:url andParams:params andTags:nil andFeature:feature andStage:stage andAlias:alias];
-}
-
-+ (BranchActivityItemProvider *)getBranchActivityItemWithDefaultURL:(NSString *)url
-                                                          andParams:(NSDictionary *)params
-                                                            andTags:(NSArray *)tags
-                                                         andFeature:(NSString *)feature
-                                                           andStage:(NSString *)stage {
-    
-    return [[BranchActivityItemProvider alloc] initWithDefaultURL:url andParams:params andTags:tags andFeature:feature andStage:stage andAlias:nil];
 }
 
 + (BranchActivityItemProvider *)getBranchActivityItemWithDefaultURL:(NSString *)url

--- a/Branch-SDK/Branch-SDK/BranchActivityItemProvider.m
+++ b/Branch-SDK/Branch-SDK/BranchActivityItemProvider.m
@@ -72,7 +72,7 @@
     } else if (activityString == UIActivityTypePostToFlickr) {
         channel = @"flickr";
     } else if (activityString == UIActivityTypePostToTencentWeibo) {
-        channel = @"tecent_weibo";
+        channel = @"tencent_weibo";
     } else if (activityString == UIActivityTypePostToTwitter) {
         channel = @"twitter";
     } else if (activityString == UIActivityTypePostToVimeo) {


### PR DESCRIPTION
Adds Branch class methods which return a UIActivityItemProvider subclass, with arguments for Branch params and properties. The subclass generate a Branch short URL that is auto tagged with the channel based on the sharing activity  the user selected. The callback for the short URL is fired on a thread other than the main thread, however, the main thread waits for the callback to return and provide the UIActivityItem. This implementation boils down sharing Branch URLs with a UIActivityView share sheet to just a few lines of code.