### PR TITLE
[BNCServerInterface encodePostToUniversalString] cleanup

### DIFF
--- a/Branch-SDK/Branch-SDK/BNCConfig.h
+++ b/Branch-SDK/Branch-SDK/BNCConfig.h
@@ -9,7 +9,7 @@
 #ifndef Branch_SDK_Config_h
 #define Branch_SDK_Config_h
 
-#define SDK_VERSION             @"0.4.6.2"
+#define SDK_VERSION             @"0.4.7"
 
 #define BNC_PROD_ENV
 //#define BNC_STAGE_ENV

--- a/Branch-TestBed/Branch-SDK Stubless Tests/Branch_SDK_Stubless_Tests.m
+++ b/Branch-TestBed/Branch-SDK Stubless Tests/Branch_SDK_Stubless_Tests.m
@@ -245,12 +245,42 @@ static NSInteger credits = 0;
     }];
 }
 
-//- (void)testPerformanceExample {
-//    // This is an example of a performance test case.
-//    [self measureBlock:^{
-//        // Put the code you want to measure the time of here.
-//    }];
-//}
+- (void)testEncodePostToUniversalStringWithExpectedParams {
+    NSDictionary *dataDict = @{ @"foo": @"bar", @"num": @1, @"dict": @{ @"sub": @1 } };
+    NSString *expectedEncodedString = @"{\"foo\":\"bar\",\"num\":1,\"dict\":{\"sub\":1}}";
+    
+    NSString *encodedValue = [BNCServerInterface encodePostToUniversalString:dataDict needSource:NO];
+    
+    XCTAssertEqualObjects(expectedEncodedString, encodedValue);
+}
+
+- (void)testEncodePostToUniversalStringWithUnexpectedParams {
+    // TODO better "unknown" type since NSDate should be handled
+    NSDictionary *dataDict = @{ @"foo": @"bar", @"date": [NSDate date] };
+    NSString *expectedEncodedString = @"{\"foo\":\"bar\"}";
+    
+    NSString *encodedValue = [BNCServerInterface encodePostToUniversalString:dataDict needSource:NO];
+    
+    XCTAssertEqualObjects(expectedEncodedString, encodedValue);
+}
+
+- (void)testEncodePostToUniversalStringWithNull {
+    NSDictionary *dataDict = @{ @"foo": [NSNull null] };
+    NSString *expectedEncodedString = @"{\"foo\":null}";
+    
+    NSString *encodedValue = [BNCServerInterface encodePostToUniversalString:dataDict needSource:NO];
+    
+    XCTAssertEqualObjects(expectedEncodedString, encodedValue);
+}
+
+- (void)testEncodePostToUniversalStringWithSubDictWithNeedSource {
+    NSDictionary *dataDict = @{ @"root": @{ @"sub": @1 } };
+    NSString *expectedEncodedString = @"{\"root\":{\"sub\":1},\"source\":\"ios\"}";
+    
+    NSString *encodedValue = [BNCServerInterface encodePostToUniversalString:dataDict needSource:YES];
+    
+    XCTAssertEqualObjects(expectedEncodedString, encodedValue);
+}
 
 @end
 

--- a/Branch.podspec
+++ b/Branch.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "Branch"
-  s.version          = "0.4.6.2"
+  s.version          = "0.4.7"
   s.summary          = "Create an HTTP URL for any piece of content in your app"
   s.description      = <<-DESC
 - Want the highest possible conversions on your sharing feature?

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,7 @@
 Branch iOS SDK change log 
 
+- v0.4.7: Rework of `BNCServerInterface encodePostToUniversalString:needSource:`
+
 - v0.4.6.2: Added unit tests
 
 - V0.4.6.1: Exposed duration in getShortUrl for tuning link click match duration


### PR DESCRIPTION
Large rework of `BNCServerInterface encodePostToUniversalString:needSource:]` method.

* Removing spaces at start/end of object, since they're not in the middle anyway. No need for extra bytes for those two spaces.
* Rather than executing `[params objectForKey:]` a dozen times inside the for loop, just storing off into a local var.
* Updating encoding of nested dictionaries to *not* include source attribute. Doesn't make sense to add this at any level other than root.
* Adding support for null (and adding note to add more support in the future).
* Adding `continue` in else case for types. If we haven't encoded it at this point, we end up trying to append nil which causes the crash mentioned in BranchMetrics/Branch-iOS-Invite-SDK#19.
* Cleaning up append calls, no need to have so many -- a couple of simple `appendFormat`s does the trick.

Also added some tests around this functionality to avoid regression. These have been lumped in with the stubless tests, which is probably not the right place, but the `Branch-SDK Tests` target is not included in the main project, doesn't have a scheme, and fails all the tests when I run it. This should be re-evaluated in the future.

CC @qinweigong and @aaustin 