### PR TITLE
Convert params to md5 (32 fixed length) before hashing

### DIFF
--- a/Branch-SDK/Branch-SDK/BNCConfig.h
+++ b/Branch-SDK/Branch-SDK/BNCConfig.h
@@ -9,7 +9,7 @@
 #ifndef Branch_SDK_Config_h
 #define Branch_SDK_Config_h
 
-#define SDK_VERSION             @"0.4.7"
+#define SDK_VERSION             @"0.4.8"
 
 #define BNC_PROD_ENV
 //#define BNC_STAGE_ENV

--- a/Branch-SDK/Branch-SDK/BNCLinkData.m
+++ b/Branch-SDK/Branch-SDK/BNCLinkData.m
@@ -7,6 +7,7 @@
 //
 
 #import "BNCLinkData.h"
+#import <CommonCrypto/CommonDigest.h>
 
 @implementation BNCLinkData
 
@@ -104,20 +105,34 @@
     return [self.data objectForKey:aKey];
 }
 
+- (NSString *)md5:(NSString *)input {
+    if (!input) { return @""; }
+    const char *cStr = [input UTF8String];
+    unsigned char digest[CC_MD5_DIGEST_LENGTH];
+    CC_MD5( cStr, (CC_LONG)strlen(cStr), digest );
+    
+    NSMutableString *output = [NSMutableString stringWithCapacity:CC_MD5_DIGEST_LENGTH * 2];
+    
+    for(int i = 0; i < CC_MD5_DIGEST_LENGTH; i++) {
+        [output appendFormat:@"%02x", digest[i]];
+    }
+    return  output;
+}
+
 - (NSUInteger)hash {
     NSUInteger result = 1;
     NSUInteger prime = 19;
-    
+
     result = prime * result + self.type;
-    result = prime * result + [[self.alias lowercaseString] hash];
-    result = prime * result + [[self.channel lowercaseString] hash];
-    result = prime * result + [[self.feature lowercaseString] hash];
-    result = prime * result + [[self.stage lowercaseString] hash];
-    result = prime * result + [[self.params lowercaseString] hash];
+    result = prime * result + [[self md5:[self.alias lowercaseString]] hash];
+    result = prime * result + [[self md5:[self.channel lowercaseString]] hash];
+    result = prime * result + [[self md5:[self.feature lowercaseString]] hash];
+    result = prime * result + [[self md5:[self.stage lowercaseString]] hash];
+    result = prime * result + [[self md5:[self.params lowercaseString]] hash];
     result = prime * result + self.duration;
     
     for (NSString *tag in self.tags) {
-        result = prime * result + [[tag lowercaseString] hash];
+        result = prime * result + [[self md5:[tag lowercaseString]] hash];
     }
     
     return result;

--- a/Branch.podspec
+++ b/Branch.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "Branch"
-  s.version          = "0.4.7"
+  s.version          = "0.4.8"
   s.summary          = "Create an HTTP URL for any piece of content in your app"
   s.description      = <<-DESC
 - Want the highest possible conversions on your sharing feature?

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,7 @@
 Branch iOS SDK change log 
 
+- v0.4.8: Fixed hashing issue on very long NSString in link caching
+
 - v0.4.7: Rework of `BNCServerInterface encodePostToUniversalString:needSource:`
 
 - v0.4.6.2: Added unit tests


### PR DESCRIPTION
@aaustin @shortstuffsushi 

Fixing issue described in https://coderwall.com/p/gcwpua/beware-of-nsstring-hash