### PR TITLE
Separating set/get of update state.

### DIFF
--- a/Branch-SDK/Branch-SDK/BNCSystemObserver.h
+++ b/Branch-SDK/Branch-SDK/BNCSystemObserver.h
@@ -20,7 +20,8 @@
 + (NSString *)getOSVersion;
 + (NSNumber *)getScreenWidth;
 + (NSNumber *)getScreenHeight;
-+ (NSNumber *)getUpdateState:(BOOL)updatePrefs;
++ (NSNumber *)getUpdateState;
++ (void)setUpdateState;
 + (NSString *)getDeviceName;
 + (NSDictionary *)getListOfApps;
 + (BOOL)isSimulator;

--- a/Branch-SDK/Branch-SDK/BNCSystemObserver.m
+++ b/Branch-SDK/Branch-SDK/BNCSystemObserver.m
@@ -123,7 +123,7 @@
     }
 }
 
-+ (NSNumber *)getUpdateState:(BOOL)updatePrefs {
++ (NSNumber *)getUpdateState {
     NSString *storedAppVersion = [BNCPreferenceHelper getAppVersion];
     NSString *currentAppVersion = [BNCSystemObserver getAppVersion];
     NSFileManager *manager = [NSFileManager defaultManager];
@@ -139,21 +139,20 @@
     int appModificationDay = (int)([[bundleAttributes fileModificationDate] timeIntervalSince1970]/(60*60*24));
 
     if (!storedAppVersion) {
-        if (updatePrefs) {
-            [BNCPreferenceHelper setAppVersion:currentAppVersion];
-        }
         if ([documentsDirAttributes fileCreationDate] && [bundleAttributes fileModificationDate] && (appCreationDay != appModificationDay)) {
             return [NSNumber numberWithInt:2];
         }
         return nil;
     } else if (![storedAppVersion isEqualToString:currentAppVersion]) {
-        if (updatePrefs) {
-            [BNCPreferenceHelper setAppVersion:currentAppVersion];
-        }
         return [NSNumber numberWithInt:2];
     } else {
         return [NSNumber numberWithInt:1];
     }
+}
+
++ (void)setUpdateState {
+    NSString *currentAppVersion = [BNCSystemObserver getAppVersion];
+    [BNCPreferenceHelper setAppVersion:currentAppVersion];
 }
 
 + (NSString *)getOS {

--- a/Branch-SDK/Branch-SDK/Branch.m
+++ b/Branch-SDK/Branch-SDK/Branch.m
@@ -232,7 +232,7 @@ static Branch *currInstance;
 
 - (void)initSessionWithLaunchOptions:(NSDictionary *)options andRegisterDeepLinkHandler:(callbackWithParams)callback {
     self.sessionparamLoadCallback = callback;
-    if (![BNCSystemObserver getUpdateState:NO] && ![self hasUser]) {
+    if (![BNCSystemObserver getUpdateState] && ![self hasUser]) {
         [BNCPreferenceHelper setIsReferrable];
     } else {
         [BNCPreferenceHelper clearIsReferrable];
@@ -267,7 +267,7 @@ static Branch *currInstance;
 }
 
 - (void)initSessionAndRegisterDeepLinkHandler:(callbackWithParams)callback {
-    if (![BNCSystemObserver getUpdateState:NO] && ![self hasUser]) {
+    if (![BNCSystemObserver getUpdateState] && ![self hasUser]) {
         [BNCPreferenceHelper setIsReferrable];
     } else {
         [BNCPreferenceHelper clearIsReferrable];
@@ -1608,6 +1608,7 @@ static Branch *currInstance;
             [BNCPreferenceHelper setDeviceFingerprintID:[response.data objectForKey:DEVICE_FINGERPRINT_ID]];
             [BNCPreferenceHelper setUserURL:[response.data objectForKey:LINK]];
             [BNCPreferenceHelper setSessionID:[response.data objectForKey:SESSION_ID]];
+            [BNCSystemObserver setUpdateState];
             
             if ([BNCPreferenceHelper getIsReferrable]) {
                 if ([response.data objectForKey:DATA]) {
@@ -1644,6 +1645,8 @@ static Branch *currInstance;
         } else if ([requestTag isEqualToString:REQ_TAG_REGISTER_OPEN]) {
             [BNCPreferenceHelper setSessionID:[response.data objectForKey:SESSION_ID]];
             [BNCPreferenceHelper setDeviceFingerprintID:[response.data objectForKey:DEVICE_FINGERPRINT_ID]];
+            [BNCSystemObserver setUpdateState];
+
             if ([response.data objectForKey:IDENTITY_ID]) {
                 [BNCPreferenceHelper setIdentityID:[response.data objectForKey:IDENTITY_ID]];
             }

--- a/Branch-SDK/Branch-SDK/BranchServerInterface.m
+++ b/Branch-SDK/Branch-SDK/BranchServerInterface.m
@@ -38,7 +38,7 @@
     if (screenHeight) [post setObject:screenHeight forKey:@"screen_height"];
     NSString *uriScheme = [BNCSystemObserver getDefaultUriScheme];
     if (uriScheme) [post setObject:uriScheme forKey:@"uri_scheme"];
-    NSNumber *updateState = [BNCSystemObserver getUpdateState:YES];
+    NSNumber *updateState = [BNCSystemObserver getUpdateState];
     if (updateState) [post setObject:updateState forKeyedSubscript:@"update"];
     if (![[BNCPreferenceHelper getLinkClickIdentifier] isEqualToString:NO_STRING_VALUE]) [post setObject:[BNCPreferenceHelper getLinkClickIdentifier] forKey:@"link_identifier"];
     [post setObject:[NSNumber numberWithBool:[BNCSystemObserver adTrackingSafe]] forKey:@"ad_tracking_enabled"];
@@ -71,7 +71,7 @@
     if (uriScheme) [post setObject:uriScheme forKey:@"uri_scheme"];
     [post setObject:[NSNumber numberWithBool:[BNCSystemObserver adTrackingSafe]] forKey:@"ad_tracking_enabled"];
     [post setObject:[NSNumber numberWithInteger:[BNCPreferenceHelper getIsReferrable]] forKey:@"is_referrable"];
-    NSNumber *updateState = [BNCSystemObserver getUpdateState:YES];
+    NSNumber *updateState = [BNCSystemObserver getUpdateState];
     if (updateState) [post setObject:updateState forKeyedSubscript:@"update"];
     [post setObject:[NSNumber numberWithBool:debug] forKey:@"debug"];
     if (![[BNCPreferenceHelper getLinkClickIdentifier] isEqualToString:NO_STRING_VALUE]) [post setObject:[BNCPreferenceHelper getLinkClickIdentifier] forKey:@"link_identifier"];


### PR DESCRIPTION
@aaustin @derrickstaten @qinweigong @Sarkar

Previously, this was being updated when a get was called, which feels somewhat unnatural.
Additionally, in the case of an install or open "failing," the update state shouldn't be updated.
UpdateState should only be set when the open/install call completes successfully.