### PR TITLE
Adding long User URL to getShortUrl failure logic.

### DIFF
--- a/Branch-SDK/Branch-SDK/Branch.m
+++ b/Branch-SDK/Branch-SDK/Branch.m
@@ -1089,8 +1089,8 @@ static Branch *currInstance;
         [longUrl appendFormat:@"stage=%@&", stage];
     }
     
-    [longUrl appendFormat:@"type=%lld&", (long long)type];
-    [longUrl appendFormat:@"matchDuration=%lld&", (long long)duration];
+    [longUrl appendFormat:@"type=%ld&", (long)type];
+    [longUrl appendFormat:@"matchDuration=%ld&", (long)duration];
     
     NSData *jsonData = [BNCEncodingUtils encodeDictionaryToJsonData:params];
     NSString *base64EncodedParams = [BNCEncodingUtils base64EncodeData:jsonData];


### PR DESCRIPTION
@aaustin @derrickstaten @qinweigong @Sarkar 

Returning User URL by itself isn't correct, but you can add all the params and make it a long url.
Note that we don't have the items available in the handleFailure: method, so we don't even try (also note this won't be the case in the callbacks branch).
Updating generateLongUrl to share the same method, since they're accomplishing the same thing.