### PR TITLE
Dont pass around link data

### DIFF
--- a/Branch-SDK/Branch-SDK/BNCLinkCache.h
+++ b/Branch-SDK/Branch-SDK/BNCLinkCache.h
@@ -13,7 +13,7 @@
 
 @property (nonatomic, strong) NSMutableDictionary *cache;
 
-- (void)setObject:(NSString *)anObject forKey:(id <NSCopying>)aKey;
-- (NSString *)objectForKey:(id)aKey;
+- (void)setObject:(NSString *)anObject forKey:(BNCLinkData *)aKey;
+- (NSString *)objectForKey:(BNCLinkData *)aKey;
 
 @end

--- a/Branch-SDK/Branch-SDK/BNCServerInterface.h
+++ b/Branch-SDK/Branch-SDK/BNCServerInterface.h
@@ -23,13 +23,11 @@ static NSString *REQ_TAG_DEBUG_DISCONNECT = @"t_debug_disconnect";
 - (void)getRequest:(NSDictionary *)params url:(NSString *)url andTag:(NSString *)requestTag callback:(BNCServerCallback)callback;
 - (void)getRequest:(NSDictionary *)params url:(NSString *)url andTag:(NSString *)requestTag log:(BOOL)log callback:(BNCServerCallback)callback;
 
-- (BNCServerResponse *)postRequest:(NSDictionary *)post url:(NSString *)url andTag:(NSString *)requestTag andLinkData:(BNCLinkData *)linkData log:(BOOL)log;
+- (BNCServerResponse *)postRequest:(NSDictionary *)post url:(NSString *)url andTag:(NSString *)requestTag log:(BOOL)log;
 - (void)postRequest:(NSDictionary *)post url:(NSString *)url andTag:(NSString *)requestTag callback:(BNCServerCallback)callback;
 - (void)postRequest:(NSDictionary *)post url:(NSString *)url andTag:(NSString *)requestTag log:(BOOL)log callback:(BNCServerCallback)callback;
-- (void)postRequest:(NSDictionary *)post url:(NSString *)url andTag:(NSString *)requestTag andLinkData:(BNCLinkData *)linkData callback:(BNCServerCallback)callback;
-- (void)postRequest:(NSDictionary *)post url:(NSString *)url andTag:(NSString *)requestTag andLinkData:(BNCLinkData *)linkData log:(BOOL)log callback:(BNCServerCallback)callback;
 
-- (void)genericHTTPRequest:(NSURLRequest *)request withTag:(NSString *)requestTag andLinkData:(BNCLinkData *)linkData callback:(BNCServerCallback)callback;
-- (BNCServerResponse *)genericHTTPRequest:(NSURLRequest *)request withTag:(NSString *)requestTag andLinkData:(BNCLinkData *)linkData;
+- (void)genericHTTPRequest:(NSURLRequest *)request withTag:(NSString *)requestTag callback:(BNCServerCallback)callback;
+- (BNCServerResponse *)genericHTTPRequest:(NSURLRequest *)request withTag:(NSString *)requestTag;
 
 @end

--- a/Branch-SDK/Branch-SDK/BNCServerInterface.m
+++ b/Branch-SDK/Branch-SDK/BNCServerInterface.m
@@ -9,7 +9,6 @@
 #import "BNCServerInterface.h"
 #import "BNCPreferenceHelper.h"
 #import "BNCConfig.h"
-#import "BNCLinkData.h"
 #import "BNCEncodingUtils.h"
 #import "BNCError.h"
 

--- a/Branch-SDK/Branch-SDK/BNCServerRequest.h
+++ b/Branch-SDK/Branch-SDK/BNCServerRequest.h
@@ -7,14 +7,12 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "BNCLinkData.h"
 #import "BNCServerInterface.h"
 
 @interface BNCServerRequest : NSObject
 
 @property (strong, nonatomic) NSString *tag;
 @property (strong, nonatomic) NSMutableDictionary *postData;
-@property (strong, nonatomic) BNCLinkData *linkData;
 @property (strong, nonatomic) BNCServerCallback callback;
 
 - (id)initWithTag:(NSString *)tag;

--- a/Branch-SDK/Branch-SDK/BNCServerRequest.m
+++ b/Branch-SDK/Branch-SDK/BNCServerRequest.m
@@ -11,7 +11,6 @@
 
 #define TAG         @"TAG"
 #define DATA        @"POSTDATA"
-#define LINK_DATA   @"LINKDATA"
 
 @interface BNCServerRequest() <NSCoding>
 
@@ -27,16 +26,12 @@
     if (self.postData) {
         [coder encodeObject:self.postData forKey:DATA];
     }
-    if (self.linkData) {
-        [coder encodeObject:self.linkData forKey:LINK_DATA];
-    }
 }
 
 - (id)initWithCoder:(NSCoder *)coder {
     if (self = [super init]) {
         self.tag = [coder decodeObjectForKey:TAG];
         self.postData = [coder decodeObjectForKey:DATA];
-        self.linkData = [coder decodeObjectForKey:LINK_DATA];
     }
     return self;
 }
@@ -47,7 +42,6 @@
 
 - (id)initWithTag:(NSString *)tag andData:(NSMutableDictionary *)postData {
     if (!tag) {
-        
         [BNCPreferenceHelper log:FILE_NAME line:LINE_NUM message:@"Invalid: server request missing tag!"];
         return nil;
     }
@@ -63,6 +57,5 @@
 - (NSString *)description {
     return [NSString stringWithFormat:@"Tag: %@; Data: %@", self.tag, self.postData];
 }
-
 
 @end

--- a/Branch-SDK/Branch-SDK/BNCServerResponse.h
+++ b/Branch-SDK/Branch-SDK/BNCServerResponse.h
@@ -7,14 +7,12 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "BNCLinkData.h"
 
 @interface BNCServerResponse : NSObject
 
 @property (nonatomic, strong) NSNumber *statusCode;
 @property (nonatomic, strong) NSString *tag;
 @property (nonatomic, strong) id data;
-@property (nonatomic, strong) BNCLinkData *linkData;
 
 - (id)initWithTag:(NSString *)tag;
 

--- a/Branch-SDK/Branch-SDK/BNCSystemObserver.m
+++ b/Branch-SDK/Branch-SDK/BNCSystemObserver.m
@@ -6,6 +6,7 @@
 //  Copyright (c) 2014 Branch Metrics. All rights reserved.
 //
 
+#import <UIKit/UIKit.h>
 #include <sys/utsname.h>
 #import "BNCPreferenceHelper.h"
 #import "BNCSystemObserver.h"

--- a/Branch-SDK/Branch-SDK/Branch.m
+++ b/Branch-SDK/Branch-SDK/Branch.m
@@ -1026,19 +1026,19 @@ static Branch *currInstance;
         [self initUserSessionAndCallCallback:NO];
     }
     
-    BNCLinkData *post = [self prepareLinkDataFor:tags andAlias:alias andType:type andMatchDuration:duration andChannel:channel andFeature:feature andStage:stage andParams:params ignoreUAString:nil];
+    BNCLinkData *linkData = [self prepareLinkDataFor:tags andAlias:alias andType:type andMatchDuration:duration andChannel:channel andFeature:feature andStage:stage andParams:params ignoreUAString:nil];
     
-    if ([self.linkCache objectForKey:post]) {
+    if ([self.linkCache objectForKey:linkData]) {
         if (callback) {
-            callback([self.linkCache objectForKey:post], nil);
+            callback([self.linkCache objectForKey:linkData], nil);
         }
         return;
     }
 
     BNCServerRequest *req = [[BNCServerRequest alloc] init];
     req.tag = REQ_TAG_GET_CUSTOM_URL;
-    req.postData = post.data;
-    req.linkData = post;
+    req.postData = linkData.data;
+
     req.callback = ^(BNCServerResponse *response, NSError *error) {
         if (error) {
             if (callback) {
@@ -1058,7 +1058,7 @@ static Branch *currInstance;
         
         // cache the link
         if (url) {
-            [self.linkCache setObject:url forKey:response.linkData];
+            [self.linkCache setObject:url forKey:linkData];
         }
 
         if (callback) {
@@ -1075,15 +1075,14 @@ static Branch *currInstance;
     
     BNCServerRequest *req = [[BNCServerRequest alloc] init];
     req.tag = REQ_TAG_GET_CUSTOM_URL;
-    BNCLinkData *post = [self prepareLinkDataFor:tags andAlias:alias andType:type andMatchDuration:duration andChannel:channel andFeature:feature andStage:stage andParams:params ignoreUAString:ignoreUAString];
+    BNCLinkData *linkData = [self prepareLinkDataFor:tags andAlias:alias andType:type andMatchDuration:duration andChannel:channel andFeature:feature andStage:stage andParams:params ignoreUAString:ignoreUAString];
     
     // If an ignore UA string is present, we always get a new url. Otherwise, if we've already seen this request, use the cached version
-    if (!ignoreUAString && [self.linkCache objectForKey:post]) {
-        shortURL = [self.linkCache objectForKey:post];
+    if (!ignoreUAString && [self.linkCache objectForKey:linkData]) {
+        shortURL = [self.linkCache objectForKey:linkData];
     }
     else {
-        req.postData = post.data;
-        req.linkData = post;
+        req.postData = linkData.data;
         
         if (self.isInitialized) {
             [BNCPreferenceHelper log:FILE_NAME line:LINE_NUM message:@"Created custom url synchronously"];
@@ -1092,7 +1091,7 @@ static Branch *currInstance;
             
             // cache the link
             if (shortURL) {
-                [self.linkCache setObject:shortURL forKey:post];
+                [self.linkCache setObject:shortURL forKey:linkData];
             }
         }
         else {

--- a/Branch-SDK/Branch-SDK/BranchServerInterface.m
+++ b/Branch-SDK/Branch-SDK/BranchServerInterface.m
@@ -118,11 +118,11 @@
 }
 
 - (void)createCustomUrl:(BNCServerRequest *)req callback:(BNCServerCallback)callback {
-    [self postRequest:req.postData url:[BNCPreferenceHelper getAPIURL:@"url"] andTag:REQ_TAG_GET_CUSTOM_URL andLinkData:req.linkData callback:callback];
+    [self postRequest:req.postData url:[BNCPreferenceHelper getAPIURL:@"url"] andTag:REQ_TAG_GET_CUSTOM_URL callback:callback];
 }
 
 - (BNCServerResponse *)createCustomUrl:(BNCServerRequest *)req {
-    return [self postRequest:req.postData url:[BNCPreferenceHelper getAPIURL:@"url"] andTag:REQ_TAG_GET_CUSTOM_URL andLinkData:req.linkData log:YES];
+    return [self postRequest:req.postData url:[BNCPreferenceHelper getAPIURL:@"url"] andTag:REQ_TAG_GET_CUSTOM_URL log:YES];
 }
 
 - (void)identifyUser:(NSDictionary *)post callback:(BNCServerCallback)callback {
@@ -213,7 +213,7 @@
     [request setHTTPBody:body];
     [request addValue:[NSString stringWithFormat:@"%lu", (unsigned long)[body length]] forHTTPHeaderField:@"Content-Length"];
 
-    [self genericHTTPRequest:request withTag:REQ_TAG_DEBUG_SCREEN andLinkData:nil callback:callback];
+    [self genericHTTPRequest:request withTag:REQ_TAG_DEBUG_SCREEN callback:callback];
 }
 
 - (void)getReferralCode:(NSDictionary *)post callback:(BNCServerCallback)callback {


### PR DESCRIPTION
@aaustin @derrickstaten @qinweigong @Sarkar 

The Link Data object no longer needs to be passed to and from the server interface. The callbacks mean that it can stay within the scope of the actual method using it.