### PR TITLE
LinkData cleanup

### DIFF
--- a/Branch-SDK/Branch-SDK/BNCLinkData.h
+++ b/Branch-SDK/Branch-SDK/BNCLinkData.h
@@ -6,7 +6,12 @@
 //  Copyright (c) 2015 Branch Metrics. All rights reserved.
 //
 
-#import "Branch.h"
+#import <Foundation/Foundation.h>
+
+typedef NS_ENUM(NSUInteger, BranchLinkType) {
+    BranchLinkTypeUnlimitedUse = 0,
+    BranchLinkTypeOneTimeUse = 1
+};
 
 @interface BNCLinkData : NSObject <NSCopying>
 
@@ -34,7 +39,6 @@
 - (void)setupIgnoreUAString:(NSString *)ignoreUAString;
 
 - (void)setObject:(id)anObject forKey:(id <NSCopying>)aKey;
-- (void)setObject:(id)obj forKeyedSubscript:(id <NSCopying>)key NS_AVAILABLE(10_8, 6_0);
 - (id)objectForKey:(id)aKey;
 
 @end

--- a/Branch-SDK/Branch-SDK/BNCLinkData.m
+++ b/Branch-SDK/Branch-SDK/BNCLinkData.m
@@ -9,6 +9,16 @@
 #import "BNCLinkData.h"
 #import "BNCEncodingUtils.h"
 
+NSString * const BNC_LINK_DATA_TAGS = @"tags";
+NSString * const BNC_LINK_DATA_LINK_TYPE = @"type";
+NSString * const BNC_LINK_DATA_ALIAS = @"alias";
+NSString * const BNC_LINK_DATA_CHANNEL = @"channel";
+NSString * const BNC_LINK_DATA_FEATURE = @"feature";
+NSString * const BNC_LINK_DATA_STAGE = @"stage";
+NSString * const BNC_LINK_DATA_DURATION = @"duration";
+NSString * const BNC_LINK_DATA_DATA = @"data";
+NSString * const BNC_LINK_DATA_IGNORE_UA_STRING = @"ignore_ua_string";
+
 @implementation BNCLinkData
 
 - (id)init {
@@ -38,62 +48,62 @@
 - (void)setupTags:(NSArray *)tags {
     if (tags) {
         _tags = tags;
-        [self.data setObject:tags forKey:TAGS];
+        [self.data setObject:tags forKey:BNC_LINK_DATA_TAGS];
     }
 }
 
 - (void)setupAlias:(NSString *)alias {
     if (alias) {
         _alias = alias;
-        [self.data setObject:alias forKey:ALIAS];
+        [self.data setObject:alias forKey:BNC_LINK_DATA_ALIAS];
     }
 }
 
 - (void)setupType:(BranchLinkType)type {
     if (type) {
         _type = type;
-        [self.data setObject:[NSNumber numberWithInt:type] forKey:LINK_TYPE];
+        [self.data setObject:[NSNumber numberWithInt:type] forKey:BNC_LINK_DATA_LINK_TYPE];
     }
 }
 
 - (void)setupMatchDuration:(NSUInteger)duration {
     if (duration > 0) {
         _duration = duration;
-        [self.data setObject:[NSNumber numberWithInteger:duration] forKey:DURATION];
+        [self.data setObject:[NSNumber numberWithInteger:duration] forKey:BNC_LINK_DATA_DURATION];
     }
 }
 
 - (void)setupChannel:(NSString *)channel {
     if (channel) {
         _channel = channel;
-        [self.data setObject:channel forKey:CHANNEL];
+        [self.data setObject:channel forKey:BNC_LINK_DATA_CHANNEL];
     }
 }
 
 - (void)setupFeature:(NSString *)feature {
     if (feature) {
         _feature = feature;
-        [self.data setObject:feature forKey:FEATURE];
+        [self.data setObject:feature forKey:BNC_LINK_DATA_FEATURE];
     }
 }
 
 - (void)setupStage:(NSString *)stage {
     if (stage) {
         _stage = stage;
-        [self.data setObject:stage forKey:STAGE];
+        [self.data setObject:stage forKey:BNC_LINK_DATA_STAGE];
     }
 }
 
 - (void)setupIgnoreUAString:(NSString *)ignoreUAString {
     if (ignoreUAString) {
         _ignoreUAString = ignoreUAString;
-        [self.data setObject:ignoreUAString forKey:IGNORE_UA_STRING];
+        [self.data setObject:ignoreUAString forKey:BNC_LINK_DATA_IGNORE_UA_STRING];
     }
 }
 
 - (void)setupParams:(NSString *)params {
     _params = params;
-    [self.data setObject:params forKey:DATA];
+    [self.data setObject:params forKey:BNC_LINK_DATA_DATA];
 }
 
 
@@ -103,10 +113,6 @@
 
 - (void)setObject:(id)anObject forKey:(id <NSCopying>)aKey {
     [self.data setObject:anObject forKey:aKey];
-}
-
-- (void)setObject:(id)obj forKeyedSubscript:(id <NSCopying>)key NS_AVAILABLE(10_8, 6_0) {
-    [self.data setObject:obj forKeyedSubscript:key];
 }
 
 - (id)objectForKey:(id)aKey {
@@ -134,41 +140,41 @@
 
 - (void)encodeWithCoder:(NSCoder *)coder {
     if (self.tags) {
-        [coder encodeObject:self.tags forKey:TAGS];
+        [coder encodeObject:self.tags forKey:BNC_LINK_DATA_TAGS];
     }
     if (self.alias) {
-        [coder encodeObject:self.alias forKey:ALIAS];
+        [coder encodeObject:self.alias forKey:BNC_LINK_DATA_ALIAS];
     }
     if (self.type) {
-        [coder encodeObject:[NSNumber numberWithInteger:self.type] forKey:LINK_TYPE];
+        [coder encodeObject:[NSNumber numberWithInteger:self.type] forKey:BNC_LINK_DATA_LINK_TYPE];
     }
     if (self.channel) {
-        [coder encodeObject:self.channel forKey:CHANNEL];
+        [coder encodeObject:self.channel forKey:BNC_LINK_DATA_CHANNEL];
     }
     if (self.feature) {
-        [coder encodeObject:self.feature forKey:FEATURE];
+        [coder encodeObject:self.feature forKey:BNC_LINK_DATA_FEATURE];
     }
     if (self.stage) {
-        [coder encodeObject:self.stage forKey:STAGE];
+        [coder encodeObject:self.stage forKey:BNC_LINK_DATA_STAGE];
     }
     if (self.params) {
-        [coder encodeObject:self.params forKey:DATA];
+        [coder encodeObject:self.params forKey:BNC_LINK_DATA_DATA];
     }
     if (self.duration > 0) {
-        [coder encodeObject:[NSNumber numberWithInteger:self.duration] forKey:DURATION];
+        [coder encodeObject:[NSNumber numberWithInteger:self.duration] forKey:BNC_LINK_DATA_DURATION];
     }
 }
 
 - (id)initWithCoder:(NSCoder *)coder {
     if (self = [super init]) {
-        self.tags = [coder decodeObjectForKey:TAGS];
-        self.alias = [coder decodeObjectForKey:ALIAS];
-        self.type = [[coder decodeObjectForKey:LINK_TYPE] intValue];
-        self.channel = [coder decodeObjectForKey:CHANNEL];
-        self.feature = [coder decodeObjectForKey:FEATURE];
-        self.stage = [coder decodeObjectForKey:STAGE];
-        self.params = [coder decodeObjectForKey:DATA];
-        self.duration = [[coder decodeObjectForKey:DURATION] intValue];
+        self.tags = [coder decodeObjectForKey:BNC_LINK_DATA_TAGS];
+        self.alias = [coder decodeObjectForKey:BNC_LINK_DATA_ALIAS];
+        self.type = [[coder decodeObjectForKey:BNC_LINK_DATA_LINK_TYPE] intValue];
+        self.channel = [coder decodeObjectForKey:BNC_LINK_DATA_CHANNEL];
+        self.feature = [coder decodeObjectForKey:BNC_LINK_DATA_FEATURE];
+        self.stage = [coder decodeObjectForKey:BNC_LINK_DATA_STAGE];
+        self.params = [coder decodeObjectForKey:BNC_LINK_DATA_DATA];
+        self.duration = [[coder decodeObjectForKey:BNC_LINK_DATA_DURATION] intValue];
     }
     return self;
 }

--- a/Branch-SDK/Branch-SDK/Branch.h
+++ b/Branch-SDK/Branch-SDK/Branch.h
@@ -8,6 +8,7 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 #import "BranchActivityItemProvider.h"
+#import "BNCLinkCache.h"
 
 typedef void (^callbackWithParams) (NSDictionary *params, NSError *error);
 typedef void (^callbackWithUrl) (NSString *url, NSError *error);
@@ -20,21 +21,10 @@ extern NSString * const BRANCH_FEATURE_TAG_INVITE;
 extern NSString * const BRANCH_FEATURE_TAG_DEAL;
 extern NSString * const BRANCH_FEATURE_TAG_GIFT;
 
-extern NSString * const TAGS;
-extern NSString * const LINK_TYPE;
-extern NSString * const ALIAS;
-extern NSString * const CHANNEL;
-extern NSString * const FEATURE;
-extern NSString * const STAGE;
-extern NSString * const DURATION;
-extern NSString * const DATA;
-extern NSString * const IGNORE_UA_STRING;
-
 typedef NS_ENUM(NSUInteger, BranchCreditHistoryOrder) {
     BranchMostRecentFirst,
     BranchLeastRecentFirst
 };
-
 
 typedef NS_ENUM(NSUInteger, BranchReferralCodeLocation) {
     BranchReferreeUser = 0,
@@ -45,11 +35,6 @@ typedef NS_ENUM(NSUInteger, BranchReferralCodeLocation) {
 typedef NS_ENUM(NSUInteger, BranchReferralCodeCalculation) {
     BranchUniqueRewards = 1,
     BranchUnlimitedRewards = 0
-};
-
-typedef NS_ENUM(NSUInteger, BranchLinkType) {
-    BranchLinkTypeUnlimitedUse = 0,
-    BranchLinkTypeOneTimeUse = 1
 };
 
 @interface Branch : NSObject

--- a/Branch-SDK/Branch-SDK/Branch.m
+++ b/Branch-SDK/Branch-SDK/Branch.m
@@ -25,16 +25,6 @@ NSString * const BRANCH_FEATURE_TAG_INVITE = @"invite";
 NSString * const BRANCH_FEATURE_TAG_DEAL = @"deal";
 NSString * const BRANCH_FEATURE_TAG_GIFT = @"gift";
 
-NSString * const TAGS = @"tags";
-NSString * const LINK_TYPE = @"type";
-NSString * const ALIAS = @"alias";
-NSString * const CHANNEL = @"channel";
-NSString * const FEATURE = @"feature";
-NSString * const STAGE = @"stage";
-NSString * const DURATION = @"duration";
-NSString * const DATA = @"data";
-NSString * const IGNORE_UA_STRING = @"ignore_ua_string";
-
 NSString * const IDENTITY = @"identity";
 NSString * const IDENTITY_ID = @"identity_id";
 NSString * const SESSION_ID = @"session_id";
@@ -47,6 +37,7 @@ NSString * const UNIQUE = @"unique";
 NSString * const MESSAGE = @"message";
 NSString * const ERROR = @"error";
 NSString * const DEVICE_FINGERPRINT_ID = @"device_fingerprint_id";
+NSString * const DATA = @"data";
 NSString * const LINK = @"link";
 NSString * const LINK_CLICK_ID = @"link_click_id";
 NSString * const URL = @"url";

--- a/Branch-SDK/Branch-SDK/BranchServerInterface.m
+++ b/Branch-SDK/Branch-SDK/BranchServerInterface.m
@@ -39,7 +39,7 @@
     NSString *uriScheme = [BNCSystemObserver getDefaultUriScheme];
     if (uriScheme) [post setObject:uriScheme forKey:@"uri_scheme"];
     NSNumber *updateState = [BNCSystemObserver getUpdateState];
-    if (updateState) [post setObject:updateState forKeyedSubscript:@"update"];
+    if (updateState) [post setObject:updateState forKey:@"update"];
     if (![[BNCPreferenceHelper getLinkClickIdentifier] isEqualToString:NO_STRING_VALUE]) [post setObject:[BNCPreferenceHelper getLinkClickIdentifier] forKey:@"link_identifier"];
     [post setObject:[NSNumber numberWithBool:[BNCSystemObserver adTrackingSafe]] forKey:@"ad_tracking_enabled"];
     [post setObject:[NSNumber numberWithInteger:[BNCPreferenceHelper getIsReferrable]] forKey:@"is_referrable"];
@@ -72,7 +72,7 @@
     [post setObject:[NSNumber numberWithBool:[BNCSystemObserver adTrackingSafe]] forKey:@"ad_tracking_enabled"];
     [post setObject:[NSNumber numberWithInteger:[BNCPreferenceHelper getIsReferrable]] forKey:@"is_referrable"];
     NSNumber *updateState = [BNCSystemObserver getUpdateState];
-    if (updateState) [post setObject:updateState forKeyedSubscript:@"update"];
+    if (updateState) [post setObject:updateState forKey:@"update"];
     [post setObject:[NSNumber numberWithBool:debug] forKey:@"debug"];
     if (![[BNCPreferenceHelper getLinkClickIdentifier] isEqualToString:NO_STRING_VALUE]) [post setObject:[BNCPreferenceHelper getLinkClickIdentifier] forKey:@"link_identifier"];
     


### PR DESCRIPTION
@aaustin @derrickstaten @qinweigong @Sarkar 

Updating LinkData items (constants, enum) to be in the proper header file.
Removing setObject:forKeyedSubscript: which isn't needed.