### PR TITLE
Fix key usage

### DIFF
--- a/Branch-SDK/Branch-SDK/BNCPreferenceHelper.m
+++ b/Branch-SDK/Branch-SDK/BNCPreferenceHelper.m
@@ -79,7 +79,7 @@ static NSString *Branch_Key = nil;
     serverInterface = [[BranchServerInterface alloc] init];
     bnc_asyncLogQueue = dispatch_queue_create("bnc_log_queue", NULL);
 
-    [serverInterface connectToDebugWithCallback:^(BNCServerResponse *response, NSError *error) {
+    [serverInterface connectToDebugWithKey:Branch_Key callback:^(BNCServerResponse *response, NSError *error) {
         if (error) {
             NSLog(@"Failed to connect to debug: %@", error);
         }
@@ -104,7 +104,7 @@ static NSString *Branch_Key = nil;
     if (BNC_Remote_Debug) {
         BNC_Remote_Debug = NO;
         
-        [serverInterface disconnectFromDebugWithCallback:NULL];
+        [serverInterface disconnectFromDebugWithKey:Branch_Key callback:NULL];
     }
 }
 
@@ -125,20 +125,20 @@ static NSString *Branch_Key = nil;
         NSLog(@"%@", log);
         
         if (BNC_Remote_Debug) {
-            [serverInterface sendLog:log callback:NULL];
+            [serverInterface sendLog:log key:Branch_Key callback:NULL];
         }
     }
 }
 
 + (void)keepDebugAlive {
     if (BNC_Remote_Debug) {
-        [serverInterface sendLog:@"" callback:NULL];
+        [serverInterface sendLog:@"" key:Branch_Key callback:NULL];
     }
 }
 
 + (void)sendScreenshot:(NSData *)data {
     if (BNC_Remote_Debug) {
-        [serverInterface sendScreenshot:data callback:NULL];
+        [serverInterface sendScreenshot:data key:Branch_Key callback:NULL];
     }
 }
 

--- a/Branch-SDK/Branch-SDK/BNCServerInterface.h
+++ b/Branch-SDK/Branch-SDK/BNCServerInterface.h
@@ -18,14 +18,14 @@ static NSString *REQ_TAG_DEBUG_DISCONNECT = @"t_debug_disconnect";
 
 @interface BNCServerInterface : NSObject
 
-- (BNCServerResponse *)getRequest:(NSDictionary *)params url:(NSString *)url;
-- (BNCServerResponse *)getRequest:(NSDictionary *)params url:(NSString *)url log:(BOOL)log;
-- (void)getRequest:(NSDictionary *)params url:(NSString *)url callback:(BNCServerCallback)callback;
-- (void)getRequest:(NSDictionary *)params url:(NSString *)url log:(BOOL)log callback:(BNCServerCallback)callback;
+- (BNCServerResponse *)getRequest:(NSDictionary *)params url:(NSString *)url key:(NSString *)key;
+- (BNCServerResponse *)getRequest:(NSDictionary *)params url:(NSString *)url key:(NSString *)key log:(BOOL)log;
+- (void)getRequest:(NSDictionary *)params url:(NSString *)url key:(NSString *)key callback:(BNCServerCallback)callback;
+- (void)getRequest:(NSDictionary *)params url:(NSString *)url key:(NSString *)key log:(BOOL)log callback:(BNCServerCallback)callback;
 
-- (BNCServerResponse *)postRequest:(NSDictionary *)post url:(NSString *)url log:(BOOL)log;
-- (void)postRequest:(NSDictionary *)post url:(NSString *)url callback:(BNCServerCallback)callback;
-- (void)postRequest:(NSDictionary *)post url:(NSString *)url log:(BOOL)log callback:(BNCServerCallback)callback;
+- (BNCServerResponse *)postRequest:(NSDictionary *)post url:(NSString *)url key:(NSString *)key log:(BOOL)log;
+- (void)postRequest:(NSDictionary *)post url:(NSString *)url key:(NSString *)key callback:(BNCServerCallback)callback;
+- (void)postRequest:(NSDictionary *)post url:(NSString *)url key:(NSString *)key log:(BOOL)log callback:(BNCServerCallback)callback;
 
 - (void)genericHTTPRequest:(NSURLRequest *)request log:(BOOL)log callback:(BNCServerCallback)callback;
 - (BNCServerResponse *)genericHTTPRequest:(NSURLRequest *)request log:(BOOL)log;

--- a/Branch-SDK/Branch-SDK/Branch.h
+++ b/Branch-SDK/Branch-SDK/Branch.h
@@ -965,6 +965,6 @@ typedef NS_ENUM(NSUInteger, BranchReferralCodeCalculation) {
 
  @warning This is meant for use internally only (exposed for the sake of testing) and should not be used by apps.
  */
-- (id)initWithInterface:(BranchServerInterface *)interface queue:(BNCServerRequestQueue *)queue cache:(BNCLinkCache *)cache;
+- (id)initWithInterface:(BranchServerInterface *)interface queue:(BNCServerRequestQueue *)queue cache:(BNCLinkCache *)cache key:(NSString *)key;
 
 @end

--- a/Branch-SDK/Branch-SDK/Branch.m
+++ b/Branch-SDK/Branch-SDK/Branch.m
@@ -86,6 +86,7 @@ static UILongPressGestureRecognizer *BNCLongPress = nil;
 @property (assign, nonatomic) BOOL shouldCallSessionInitCallback;
 @property (assign, nonatomic) BOOL appListCheckEnabled;
 @property (strong, nonatomic) BNCLinkCache *linkCache;
+@property (strong, nonatomic) NSString *branchKey;
 
 @end
 
@@ -148,11 +149,12 @@ static UILongPressGestureRecognizer *BNCLongPress = nil;
     return [Branch getInstanceInternal:branchKey];
 }
 
-- (id)initWithInterface:(BranchServerInterface *)interface queue:(BNCServerRequestQueue *)queue cache:(BNCLinkCache *)cache {
+- (id)initWithInterface:(BranchServerInterface *)interface queue:(BNCServerRequestQueue *)queue cache:(BNCLinkCache *)cache key:(NSString *)key {
     if (self = [super init]) {
         _bServerInterface = interface;
         _requestQueue = queue;
         _linkCache = cache;
+        _branchKey = key;
         
         _isInitialized = NO;
         _shouldCallSessionInitCallback = YES;
@@ -1042,7 +1044,7 @@ static UILongPressGestureRecognizer *BNCLongPress = nil;
         
         [BNCPreferenceHelper setLastRunBranchKey:key];
 
-        branch = [[Branch alloc] initWithInterface:[[BranchServerInterface alloc] init] queue:[BNCServerRequestQueue getInstance] cache:[[BNCLinkCache alloc] init]];
+        branch = [[Branch alloc] initWithInterface:[[BranchServerInterface alloc] init] queue:[BNCServerRequestQueue getInstance] cache:[[BNCLinkCache alloc] init] key:key];
     });
 
     return branch;
@@ -1116,7 +1118,7 @@ static UILongPressGestureRecognizer *BNCLongPress = nil;
         
         if (self.isInitialized) {
             [BNCPreferenceHelper log:FILE_NAME line:LINE_NUM message:@"Created custom url synchronously"];
-            BNCServerResponse *serverResponse = [self.bServerInterface createCustomUrl:req];
+            BNCServerResponse *serverResponse = [self.bServerInterface createCustomUrl:req key:self.branchKey];
             shortURL = [serverResponse.data objectForKey:URL];
             
             // cache the link
@@ -1358,67 +1360,67 @@ static UILongPressGestureRecognizer *BNCLongPress = nil;
             
             if ([req.tag isEqualToString:REQ_TAG_REGISTER_INSTALL]) {
                 [BNCPreferenceHelper log:FILE_NAME line:LINE_NUM message:@"calling register install"];
-                [self.bServerInterface registerInstall:[BNCPreferenceHelper isDebug] callback:wrappedCallback];
+                [self.bServerInterface registerInstall:[BNCPreferenceHelper isDebug] key:self.branchKey callback:wrappedCallback];
             }
             else if ([req.tag isEqualToString:REQ_TAG_REGISTER_OPEN]) {
                 [BNCPreferenceHelper log:FILE_NAME line:LINE_NUM message:@"calling register open"];
-                [self.bServerInterface registerOpen:[BNCPreferenceHelper isDebug] callback:wrappedCallback];
+                [self.bServerInterface registerOpen:[BNCPreferenceHelper isDebug] key:self.branchKey callback:wrappedCallback];
             }
             else if ([req.tag isEqualToString:REQ_TAG_GET_REFERRAL_COUNTS] && [self hasSession]) {
                 [BNCPreferenceHelper log:FILE_NAME line:LINE_NUM message:@"calling get referrals"];
-                [self.bServerInterface getReferralCountsWithCallback:wrappedCallback];
+                [self.bServerInterface getReferralCountsWithKey:self.branchKey callback:wrappedCallback];
             }
             else if ([req.tag isEqualToString:REQ_TAG_GET_REWARDS] && [self hasSession]) {
                 [BNCPreferenceHelper log:FILE_NAME line:LINE_NUM message:@"calling get rewards"];
-                [self.bServerInterface getRewardsWithCallback:wrappedCallback];
+                [self.bServerInterface getRewardsWithKey:self.branchKey callback:wrappedCallback];
             }
             else if ([req.tag isEqualToString:REQ_TAG_REDEEM_REWARDS] && [self hasSession]) {
                 [BNCPreferenceHelper log:FILE_NAME line:LINE_NUM message:@"calling redeem rewards"];
-                [self.bServerInterface redeemRewards:req.postData callback:wrappedCallback];
+                [self.bServerInterface redeemRewards:req.postData key:self.branchKey callback:wrappedCallback];
             }
             else if ([req.tag isEqualToString:REQ_TAG_COMPLETE_ACTION] && [self hasSession]) {
                 [BNCPreferenceHelper log:FILE_NAME line:LINE_NUM message:@"calling completed action"];
-                [self.bServerInterface userCompletedAction:req.postData callback:wrappedCallback];
+                [self.bServerInterface userCompletedAction:req.postData key:self.branchKey callback:wrappedCallback];
             }
             else if ([req.tag isEqualToString:REQ_TAG_GET_CUSTOM_URL] && [self hasSession]) {
                 [BNCPreferenceHelper log:FILE_NAME line:LINE_NUM message:@"calling create custom url"];
-                [self.bServerInterface createCustomUrl:req callback:wrappedCallback];
+                [self.bServerInterface createCustomUrl:req key:self.branchKey callback:wrappedCallback];
             }
             else if ([req.tag isEqualToString:REQ_TAG_IDENTIFY] && [self hasSession]) {
                 [BNCPreferenceHelper log:FILE_NAME line:LINE_NUM message:@"calling identify user"];
-                [self.bServerInterface identifyUser:req.postData callback:wrappedCallback];
+                [self.bServerInterface identifyUser:req.postData key:self.branchKey callback:wrappedCallback];
             }
             else if ([req.tag isEqualToString:REQ_TAG_LOGOUT] && [self hasSession]) {
                 [BNCPreferenceHelper log:FILE_NAME line:LINE_NUM message:@"calling logout"];
-                [self.bServerInterface logoutUser:req.postData callback:wrappedCallback];
+                [self.bServerInterface logoutUser:req.postData key:self.branchKey callback:wrappedCallback];
             }
             else if ([req.tag isEqualToString:REQ_TAG_REGISTER_CLOSE] && [self hasSession]) {
                 [BNCPreferenceHelper log:FILE_NAME line:LINE_NUM message:@"calling close"];
-                [self.bServerInterface registerCloseWithCallback:wrappedCallback];
+                [self.bServerInterface registerCloseWithKey:self.branchKey callback:wrappedCallback];
             }
             else if ([req.tag isEqualToString:REQ_TAG_GET_REWARD_HISTORY] && [self hasSession]) {
                 [BNCPreferenceHelper log:FILE_NAME line:LINE_NUM message:@"calling get reward history"];
-                [self.bServerInterface getCreditHistory:req.postData callback:wrappedCallback];
+                [self.bServerInterface getCreditHistory:req.postData key:self.branchKey callback:wrappedCallback];
             }
             else if ([req.tag isEqualToString:REQ_TAG_GET_REFERRAL_CODE] && [self hasSession]) {
                 [BNCPreferenceHelper log:FILE_NAME line:LINE_NUM message:@"calling get/create referral code"];
-                [self.bServerInterface getReferralCode:req.postData callback:wrappedCallback];
+                [self.bServerInterface getReferralCode:req.postData key:self.branchKey callback:wrappedCallback];
             }
             else if ([req.tag isEqualToString:REQ_TAG_VALIDATE_REFERRAL_CODE] && [self hasSession]) {
                 [BNCPreferenceHelper log:FILE_NAME line:LINE_NUM message:@"calling validate referral code"];
-                [self.bServerInterface validateReferralCode:req.postData callback:wrappedCallback];
+                [self.bServerInterface validateReferralCode:req.postData key:self.branchKey callback:wrappedCallback];
             }
             else if ([req.tag isEqualToString:REQ_TAG_APPLY_REFERRAL_CODE] && [self hasSession]) {
                 [BNCPreferenceHelper log:FILE_NAME line:LINE_NUM message:@"calling apply referral code"];
-                [self.bServerInterface applyReferralCode:req.postData callback:wrappedCallback];
+                [self.bServerInterface applyReferralCode:req.postData key:self.branchKey callback:wrappedCallback];
             }
             else if ([req.tag isEqualToString:REQ_TAG_GET_LIST_OF_APPS] && [self hasSession]) {
                 [BNCPreferenceHelper log:FILE_NAME line:LINE_NUM message:@"calling get apps"];
-                [self.bServerInterface retrieveAppsToCheckWithCallback:wrappedCallback];
+                [self.bServerInterface retrieveAppsToCheckWithKey:self.branchKey callback:wrappedCallback];
             }
             else if ([req.tag isEqualToString:REQ_TAG_UPLOAD_LIST_OF_APPS] && [self hasSession]) {
                 [BNCPreferenceHelper log:FILE_NAME line:LINE_NUM message:@"calling upload apps"];
-                [self.bServerInterface uploadListOfApps:req.postData callback:wrappedCallback];
+                [self.bServerInterface uploadListOfApps:req.postData key:self.branchKey callback:wrappedCallback];
             }
         }
     }

--- a/Branch-SDK/Branch-SDK/BranchServerInterface.h
+++ b/Branch-SDK/Branch-SDK/BranchServerInterface.h
@@ -29,32 +29,28 @@ static NSString *REQ_TAG_GET_LIST_OF_APPS = @"t_get_list_of_apps";
 
 @interface BranchServerInterface : BNCServerInterface
 
-- (void)registerInstall:(BOOL)debug callback:(BNCServerCallback)callback;
-- (void)registerOpen:(BOOL)debug callback:(BNCServerCallback)callback;
-- (void)registerCloseWithCallback:(BNCServerCallback)callback;
-- (void)getReferralCountsWithCallback:(BNCServerCallback)callback;
-- (void)getCreditHistory:(NSDictionary *)query callback:(BNCServerCallback)callback;
-- (void)userCompletedAction:(NSDictionary *)post callback:(BNCServerCallback)callback;
-- (void)getRewardsWithCallback:(BNCServerCallback)callback;
-- (void)redeemRewards:(NSDictionary *)post callback:(BNCServerCallback)callback;
-- (void)createCustomUrl:(BNCServerRequest *)post callback:(BNCServerCallback)callback;
-- (void)identifyUser:(NSDictionary *)post callback:(BNCServerCallback)callback;
-- (void)logoutUser:(NSDictionary *)post callback:(BNCServerCallback)callback;
-- (void)addProfileParams:(NSDictionary *)post withParams:(NSDictionary *)params callback:(BNCServerCallback)callback;
-- (void)setProfileParams:(NSDictionary *)post withParams:(NSDictionary *)params callback:(BNCServerCallback)callback;
-- (void)appendProfileParams:(NSDictionary *)post withParams:(NSDictionary *)params callback:(BNCServerCallback)callback;
-- (void)unionProfileParams:(NSDictionary *)post withParams:(NSDictionary *)params callback:(BNCServerCallback)callback;
-- (void)getReferralCode:(NSDictionary *)post callback:(BNCServerCallback)callback;
-- (void)validateReferralCode:(NSDictionary *)post callback:(BNCServerCallback)callback;
-- (void)applyReferralCode:(NSDictionary *)post callback:(BNCServerCallback)callback;
-- (void)uploadListOfApps:(NSDictionary *)post callback:(BNCServerCallback)callback;
-- (void)retrieveAppsToCheckWithCallback:(BNCServerCallback)callback;
+- (void)registerInstall:(BOOL)debug key:(NSString *)key callback:(BNCServerCallback)callback;
+- (void)registerOpen:(BOOL)debug key:(NSString *)key callback:(BNCServerCallback)callback;
+- (void)registerCloseWithKey:(NSString *)key callback:(BNCServerCallback)callback;
+- (void)getReferralCountsWithKey:(NSString *)key callback:(BNCServerCallback)callback;
+- (void)getCreditHistory:(NSDictionary *)query key:(NSString *)key callback:(BNCServerCallback)callback;
+- (void)userCompletedAction:(NSDictionary *)post key:(NSString *)key callback:(BNCServerCallback)callback;
+- (void)getRewardsWithKey:(NSString *)key callback:(BNCServerCallback)callback;
+- (void)redeemRewards:(NSDictionary *)post key:(NSString *)key callback:(BNCServerCallback)callback;
+- (void)createCustomUrl:(BNCServerRequest *)post key:(NSString *)key callback:(BNCServerCallback)callback;
+- (void)identifyUser:(NSDictionary *)post key:(NSString *)key callback:(BNCServerCallback)callback;
+- (void)logoutUser:(NSDictionary *)post key:(NSString *)key callback:(BNCServerCallback)callback;
+- (void)getReferralCode:(NSDictionary *)post key:(NSString *)key callback:(BNCServerCallback)callback;
+- (void)validateReferralCode:(NSDictionary *)post key:(NSString *)key callback:(BNCServerCallback)callback;
+- (void)applyReferralCode:(NSDictionary *)post key:(NSString *)key callback:(BNCServerCallback)callback;
+- (void)uploadListOfApps:(NSDictionary *)post key:(NSString *)key callback:(BNCServerCallback)callback;
+- (void)retrieveAppsToCheckWithKey:(NSString *)key callback:(BNCServerCallback)callback;
 
-- (void)connectToDebugWithCallback:(BNCServerCallback)callback;
-- (void)sendLog:(NSString *)log callback:(BNCServerCallback)callback;
-- (void)sendScreenshot:(NSData *)data callback:(BNCServerCallback)callback;
-- (void)disconnectFromDebugWithCallback:(BNCServerCallback)callback;
+- (void)connectToDebugWithKey:(NSString *)key callback:(BNCServerCallback)callback;
+- (void)sendLog:(NSString *)log key:(NSString *)key callback:(BNCServerCallback)callback;
+- (void)sendScreenshot:(NSData *)data key:(NSString *)key callback:(BNCServerCallback)callback;
+- (void)disconnectFromDebugWithKey:(NSString *)key callback:(BNCServerCallback)callback;
 
-- (BNCServerResponse *)createCustomUrl:(BNCServerRequest *)req;
+- (BNCServerResponse *)createCustomUrl:(BNCServerRequest *)req key:(NSString *)key;
 
 @end

--- a/Branch-SDK/Branch-SDK/BranchServerInterface.m
+++ b/Branch-SDK/Branch-SDK/BranchServerInterface.m
@@ -13,7 +13,7 @@
 
 @implementation BranchServerInterface
 
-- (void)registerInstall:(BOOL)debug callback:(BNCServerCallback)callback {
+- (void)registerInstall:(BOOL)debug key:(NSString *)key callback:(BNCServerCallback)callback{
     NSMutableDictionary *post = [[NSMutableDictionary alloc] init];
     
     BOOL isRealHardwareId;
@@ -45,10 +45,10 @@
     [post setObject:[NSNumber numberWithInteger:[BNCPreferenceHelper getIsReferrable]] forKey:@"is_referrable"];
     [post setObject:[NSNumber numberWithBool:debug] forKey:@"debug"];
     
-    [self postRequest:post url:[BNCPreferenceHelper getAPIURL:@"install"] callback:callback];
+    [self postRequest:post url:[BNCPreferenceHelper getAPIURL:@"install"] key:key callback:callback];
 }
 
-- (void)registerOpen:(BOOL)debug callback:(BNCServerCallback)callback {
+- (void)registerOpen:(BOOL)debug key:(NSString *)key callback:(BNCServerCallback)callback {
     NSMutableDictionary *post = [[NSMutableDictionary alloc] init];
     
     if ([[BNCPreferenceHelper getDeviceFingerprintID] isEqualToString:NO_STRING_VALUE]) {
@@ -76,92 +76,64 @@
     [post setObject:[NSNumber numberWithBool:debug] forKey:@"debug"];
     if (![[BNCPreferenceHelper getLinkClickIdentifier] isEqualToString:NO_STRING_VALUE]) [post setObject:[BNCPreferenceHelper getLinkClickIdentifier] forKey:@"link_identifier"];
     
-    [self postRequest:post url:[BNCPreferenceHelper getAPIURL:@"open"] callback:callback];
+    [self postRequest:post url:[BNCPreferenceHelper getAPIURL:@"open"] key:key callback:callback];
 }
 
-- (void)registerCloseWithCallback:(BNCServerCallback)callback{
+- (void)registerCloseWithKey:(NSString *)key callback:(BNCServerCallback)callback{
     NSMutableDictionary *post = [[NSMutableDictionary alloc] init];
     
     [post setObject:[BNCPreferenceHelper getIdentityID] forKey:@"identity_id"];
     [post setObject:[BNCPreferenceHelper getSessionID] forKey:@"session_id"];
     [post setObject:[BNCPreferenceHelper getDeviceFingerprintID] forKey:@"device_fingerprint_id"];
     
-    [self postRequest:post url:[BNCPreferenceHelper getAPIURL:@"close"] callback:callback];
+    [self postRequest:post url:[BNCPreferenceHelper getAPIURL:@"close"] key:key callback:callback];
 }
 
-- (void)uploadListOfApps:(NSDictionary *)post callback:(BNCServerCallback)callback {
-    [self postRequest:post url:[BNCPreferenceHelper getAPIURL:@"applist"] callback:callback];
+- (void)uploadListOfApps:(NSDictionary *)post key:(NSString *)key callback:(BNCServerCallback)callback {
+    [self postRequest:post url:[BNCPreferenceHelper getAPIURL:@"applist"] key:key callback:callback];
 }
 
-- (void)retrieveAppsToCheckWithCallback:(BNCServerCallback)callback {
-    return [self getRequest:nil url:[BNCPreferenceHelper getAPIURL:@"applist"] callback:callback];
+- (void)retrieveAppsToCheckWithKey:(NSString *)key callback:(BNCServerCallback)callback {
+    return [self getRequest:nil url:[BNCPreferenceHelper getAPIURL:@"applist"] key:key callback:callback];
 }
 
-- (void)userCompletedAction:(NSDictionary *)post callback:(BNCServerCallback)callback {
-    [self postRequest:post url:[BNCPreferenceHelper getAPIURL:@"event"] callback:callback];
+- (void)userCompletedAction:(NSDictionary *)post key:(NSString *)key callback:(BNCServerCallback)callback {
+    [self postRequest:post url:[BNCPreferenceHelper getAPIURL:@"event"] key:key callback:callback];
 }
 
-- (void)getReferralCountsWithCallback:(BNCServerCallback)callback {
-    [self getRequest:nil url:[BNCPreferenceHelper getAPIURL:[NSString stringWithFormat:@"%@/%@", @"referrals", [BNCPreferenceHelper getIdentityID]]] callback:callback];
+- (void)getReferralCountsWithKey:(NSString *)key callback:(BNCServerCallback)callback {
+    [self getRequest:nil url:[BNCPreferenceHelper getAPIURL:[NSString stringWithFormat:@"%@/%@", @"referrals", [BNCPreferenceHelper getIdentityID]]] key:key callback:callback];
 }
 
-- (void)getRewardsWithCallback:(BNCServerCallback)callback {
-    [self getRequest:nil url:[BNCPreferenceHelper getAPIURL:[NSString stringWithFormat:@"%@/%@", @"credits", [BNCPreferenceHelper getIdentityID]]] callback:callback];
+- (void)getRewardsWithKey:(NSString *)key callback:(BNCServerCallback)callback {
+    [self getRequest:nil url:[BNCPreferenceHelper getAPIURL:[NSString stringWithFormat:@"%@/%@", @"credits", [BNCPreferenceHelper getIdentityID]]] key:key callback:callback];
 }
 
-- (void)redeemRewards:(NSDictionary *)post callback:(BNCServerCallback)callback {
-    [self postRequest:post url:[BNCPreferenceHelper getAPIURL:@"redeem"] callback:callback];
+- (void)redeemRewards:(NSDictionary *)post key:(NSString *)key callback:(BNCServerCallback)callback {
+    [self postRequest:post url:[BNCPreferenceHelper getAPIURL:@"redeem"] key:key callback:callback];
 }
 
-- (void)getCreditHistory:(NSDictionary *)post callback:(BNCServerCallback)callback {
-    [self postRequest:post url:[BNCPreferenceHelper getAPIURL:@"credithistory"] callback:callback];
+- (void)getCreditHistory:(NSDictionary *)post key:(NSString *)key callback:(BNCServerCallback)callback {
+    [self postRequest:post url:[BNCPreferenceHelper getAPIURL:@"credithistory"] key:key callback:callback];
 }
 
-- (void)createCustomUrl:(BNCServerRequest *)req callback:(BNCServerCallback)callback {
-    [self postRequest:req.postData url:[BNCPreferenceHelper getAPIURL:@"url"] callback:callback];
+- (void)createCustomUrl:(BNCServerRequest *)req key:(NSString *)key callback:(BNCServerCallback)callback {
+    [self postRequest:req.postData url:[BNCPreferenceHelper getAPIURL:@"url"] key:key callback:callback];
 }
 
-- (BNCServerResponse *)createCustomUrl:(BNCServerRequest *)req {
-    return [self postRequest:req.postData url:[BNCPreferenceHelper getAPIURL:@"url"] log:YES];
+- (BNCServerResponse *)createCustomUrl:(BNCServerRequest *)req key:(NSString *)key {
+    return [self postRequest:req.postData url:[BNCPreferenceHelper getAPIURL:@"url"] key:key log:YES];
 }
 
-- (void)identifyUser:(NSDictionary *)post callback:(BNCServerCallback)callback {
-    [self postRequest:post url:[BNCPreferenceHelper getAPIURL:@"profile"] callback:callback];
+- (void)identifyUser:(NSDictionary *)post key:(NSString *)key callback:(BNCServerCallback)callback {
+    [self postRequest:post url:[BNCPreferenceHelper getAPIURL:@"profile"] key:key callback:callback];
 }
 
-- (void)logoutUser:(NSDictionary *)post callback:(BNCServerCallback)callback {
-    [self postRequest:post url:[BNCPreferenceHelper getAPIURL:@"logout"] callback:callback];
+- (void)logoutUser:(NSDictionary *)post key:(NSString *)key callback:(BNCServerCallback)callback {
+    [self postRequest:post url:[BNCPreferenceHelper getAPIURL:@"logout"] key:key callback:callback];
 }
 
-- (void)addProfileParams:(NSDictionary *)post withParams:(NSDictionary *)params callback:(BNCServerCallback)callback {
-    NSMutableDictionary *newPost = [post mutableCopy];
-    [newPost setObject:params forKey:@"add"];
-    [self updateProfileParams:newPost callback:callback];
-}
-
-- (void)setProfileParams:(NSDictionary *)post withParams:(NSDictionary *)params callback:(BNCServerCallback)callback {
-    NSMutableDictionary *newPost = [post mutableCopy];
-    [newPost setObject:params forKey:@"set"];
-    [self updateProfileParams:newPost callback:callback];
-}
-
-- (void)appendProfileParams:(NSDictionary *)post withParams:(NSDictionary *)params callback:(BNCServerCallback)callback {
-    NSMutableDictionary *newPost = [post mutableCopy];
-    [newPost setObject:params forKey:@"append"];
-    [self updateProfileParams:newPost callback:callback];
-}
-
-- (void)unionProfileParams:(NSDictionary *)post withParams:(NSDictionary *)params callback:(BNCServerCallback)callback {
-    NSMutableDictionary *newPost = [post mutableCopy];
-    [newPost setObject:params forKey:@"union"];
-    [self updateProfileParams:newPost callback:callback];
-}
-
-- (void)updateProfileParams:(NSDictionary *)post callback:(BNCServerCallback)callback {
-    [self postRequest:post url:[BNCPreferenceHelper getAPIURL:@"profile"] callback:callback];
-}
-
-- (void)connectToDebugWithCallback:(BNCServerCallback)callback {
+- (void)connectToDebugWithKey:(NSString *)key callback:(BNCServerCallback)callback {
     NSMutableDictionary *post = [[NSMutableDictionary alloc] init];
     [post setObject:[BNCPreferenceHelper getDeviceFingerprintID] forKey:@"device_fingerprint_id"];
     [post setObject:[BNCSystemObserver getDeviceName] forKey:@"device_name"];
@@ -170,28 +142,36 @@
     [post setObject:[BNCSystemObserver getModel] forKey:@"model"];
     [post setObject:[NSNumber numberWithBool:[BNCSystemObserver isSimulator]] forKey:@"is_simulator"];
     
-    [self postRequest:post url:[BNCPreferenceHelper getAPIURL:@"debug/connect"] log:NO callback:callback];
+    [self postRequest:post url:[BNCPreferenceHelper getAPIURL:@"debug/connect"] key:key log:NO callback:callback];
 }
 
-- (void)disconnectFromDebugWithCallback:(BNCServerCallback)callback {
+- (void)disconnectFromDebugWithKey:(NSString *)key callback:(BNCServerCallback)callback {
     NSMutableDictionary *post = [[NSMutableDictionary alloc] init];
     [post setObject:[BNCPreferenceHelper getDeviceFingerprintID] forKey:@"device_fingerprint_id"];
     
-    [self postRequest:post url:[BNCPreferenceHelper getAPIURL:@"debug/disconnect"] log:NO callback:callback];
+    [self postRequest:post url:[BNCPreferenceHelper getAPIURL:@"debug/disconnect"] key:key log:NO callback:callback];
 }
 
-- (void)sendLog:(NSString *)log callback:(BNCServerCallback)callback {
+- (void)sendLog:(NSString *)log key:(NSString *)key callback:(BNCServerCallback)callback {
     NSMutableDictionary *post = [NSMutableDictionary dictionaryWithObject:log forKey:@"log"];
     [post setObject:[BNCPreferenceHelper getDeviceFingerprintID] forKey:@"device_fingerprint_id"];
     
-    [self postRequest:post url:[BNCPreferenceHelper getAPIURL:@"debug/log"] log:NO callback:callback];
+    [self postRequest:post url:[BNCPreferenceHelper getAPIURL:@"debug/log"] key:key log:NO callback:callback];
 }
 
-- (void)sendScreenshot:(NSData *)data callback:(BNCServerCallback)callback {
+- (void)sendScreenshot:(NSData *)data key:(NSString *)key callback:(BNCServerCallback)callback {
     NSMutableURLRequest *request = [[NSMutableURLRequest alloc] init];
     NSString *file = @"BNC_Debug_Screen.png";
     
-    [request setURL:[NSURL URLWithString:[NSString stringWithFormat:@"%@?%@=%@&app_id=%@&sdk=ios%@&device_fingerprint_id=%@", [BNCPreferenceHelper getAPIURL:@"debug/screenshot"], KEY_BRANCH_KEY, [BNCPreferenceHelper getBranchKey], [BNCPreferenceHelper getAppKey], SDK_VERSION, [BNCPreferenceHelper getDeviceFingerprintID]]]];
+    NSString *keyString;
+    if ([key hasPrefix:@"key_"]) {
+        keyString = [NSString stringWithFormat:@"%@=%@", KEY_BRANCH_KEY, key];
+    }
+    else {
+        keyString = [NSString stringWithFormat:@"app_id=%@", key];
+    }
+
+    [request setURL:[NSURL URLWithString:[NSString stringWithFormat:@"%@?%@&sdk=ios%@&device_fingerprint_id=%@", [BNCPreferenceHelper getAPIURL:@"debug/screenshot"], keyString, SDK_VERSION, [BNCPreferenceHelper getDeviceFingerprintID]]]];
     [request setHTTPMethod:@"POST"];
     
     NSString *boundary = @"---------------------------Boundary Line---------------------------";
@@ -216,16 +196,18 @@
     [self genericHTTPRequest:request log:YES callback:callback];
 }
 
-- (void)getReferralCode:(NSDictionary *)post callback:(BNCServerCallback)callback {
-    [self postRequest:post url:[BNCPreferenceHelper getAPIURL:@"referralcode"] callback:callback];
+- (void)getReferralCode:(NSDictionary *)post key:(NSString *)key callback:(BNCServerCallback)callback {
+    [self postRequest:post url:[BNCPreferenceHelper getAPIURL:@"referralcode"] key:key callback:callback];
 }
 
-- (void)validateReferralCode:(NSDictionary *)post callback:(BNCServerCallback)callback {
-    [self postRequest:post url:[[BNCPreferenceHelper getAPIURL:@"referralcode/"] stringByAppendingString:[post objectForKey:@"referral_code"]] callback:callback];
+- (void)validateReferralCode:(NSDictionary *)post key:(NSString *)key callback:(BNCServerCallback)callback {
+    NSString *url = [[BNCPreferenceHelper getAPIURL:@"referralcode/"] stringByAppendingString:post[@"referral_code"]];
+    [self postRequest:post url:url key:key callback:callback];
 }
 
-- (void)applyReferralCode:(NSDictionary *)post callback:(BNCServerCallback)callback {
-    [self postRequest:post url:[[BNCPreferenceHelper getAPIURL:@"applycode/"] stringByAppendingString:[post objectForKey:@"referral_code"]] callback:callback];
+- (void)applyReferralCode:(NSDictionary *)post key:(NSString *)key callback:(BNCServerCallback)callback {
+    NSString *url = [[BNCPreferenceHelper getAPIURL:@"applycode/"] stringByAppendingString:post[@"referral_code"]];
+    [self postRequest:post url:url key:key callback:callback];
 }
 
 @end

--- a/Branch-TestBed/Branch-SDK Functionality Tests/BNCPreferenceHelperTests.m
+++ b/Branch-TestBed/Branch-SDK Functionality Tests/BNCPreferenceHelperTests.m
@@ -21,6 +21,7 @@
     [super setUp];
 
     [[LSNocilla sharedInstance] start];
+    [BNCPreferenceHelper setBranchKey:@"foo"];
 }
 
 + (void)tearDown {

--- a/Branch-TestBed/Branch-SDK Functionality Tests/BNCServerInterfaceTests.m
+++ b/Branch-TestBed/Branch-SDK Functionality Tests/BNCServerInterfaceTests.m
@@ -52,7 +52,7 @@ typedef void (^UrlConnectionCallback)(NSURLResponse *, NSData *, NSError *);
     
     // Make the request
     XCTestExpectation *getRequestExpectation = [self expectationWithDescription:@"GET Request Expectation"];
-    [serverInterface getRequest:nil url:@"http://foo" callback:^(BNCServerResponse *response, NSError *error) {
+    [serverInterface getRequest:nil url:@"http://foo" key:@"key_foo" callback:^(BNCServerResponse *response, NSError *error) {
         XCTAssertNotNil(error);
 
         [getRequestExpectation fulfill];
@@ -75,7 +75,7 @@ typedef void (^UrlConnectionCallback)(NSURLResponse *, NSData *, NSError *);
     
     // Make the request
     XCTestExpectation *getRequestExpectation = [self expectationWithDescription:@"GET Request Expectation"];
-    [serverInterface getRequest:nil url:@"http://foo" callback:^(BNCServerResponse *response, NSError *error) {
+    [serverInterface getRequest:nil url:@"http://foo" key:@"key_foo" callback:^(BNCServerResponse *response, NSError *error) {
         XCTAssertNil(error);
         
         [getRequestExpectation fulfill];
@@ -96,7 +96,7 @@ typedef void (^UrlConnectionCallback)(NSURLResponse *, NSData *, NSError *);
     
     // Make the request
     XCTestExpectation *getRequestExpectation = [self expectationWithDescription:@"GET Request Expectation"];
-    [serverInterface getRequest:nil url:@"http://foo" callback:^(BNCServerResponse *response, NSError *error) {
+    [serverInterface getRequest:nil url:@"http://foo" key:@"key_foo" callback:^(BNCServerResponse *response, NSError *error) {
         XCTAssertNotNil(error);
         
         [getRequestExpectation fulfill];
@@ -117,7 +117,7 @@ typedef void (^UrlConnectionCallback)(NSURLResponse *, NSData *, NSError *);
     
     // Make the request
     XCTestExpectation *postRequestExpectation = [self expectationWithDescription:@"POST Request Expectation"];
-    [serverInterface postRequest:nil url:@"http://foo" callback:^(BNCServerResponse *response, NSError *error) {
+    [serverInterface postRequest:nil url:@"http://foo" key:@"key_foo" callback:^(BNCServerResponse *response, NSError *error) {
         XCTAssertNotNil(error);
         
         [postRequestExpectation fulfill];
@@ -138,7 +138,7 @@ typedef void (^UrlConnectionCallback)(NSURLResponse *, NSData *, NSError *);
     
     // Make the request
     XCTestExpectation *postRequestExpectation = [self expectationWithDescription:@"POST Request Expectation"];
-    [serverInterface postRequest:nil url:@"http://foo" callback:^(BNCServerResponse *response, NSError *error) {
+    [serverInterface postRequest:nil url:@"http://foo" key:@"key_foo" callback:^(BNCServerResponse *response, NSError *error) {
         XCTAssertNil(error);
         
         [postRequestExpectation fulfill];
@@ -159,7 +159,7 @@ typedef void (^UrlConnectionCallback)(NSURLResponse *, NSData *, NSError *);
     
     // Make the request
     XCTestExpectation *postRequestExpectation = [self expectationWithDescription:@"POST Request Expectation"];
-    [serverInterface postRequest:nil url:@"http://foo" callback:^(BNCServerResponse *response, NSError *error) {
+    [serverInterface postRequest:nil url:@"http://foo" key:@"key_foo" callback:^(BNCServerResponse *response, NSError *error) {
         XCTAssertNotNil(error);
         
         [postRequestExpectation fulfill];

--- a/Branch-TestBed/Branch-SDK Functionality Tests/BNCServerInterfaceTests.m
+++ b/Branch-TestBed/Branch-SDK Functionality Tests/BNCServerInterfaceTests.m
@@ -38,6 +38,40 @@ typedef void (^UrlConnectionCallback)(NSURLResponse *, NSData *, NSError *);
     [super tearDown];
 }
 
+
+#pragma mark - Key tests
+
+- (void)testParamAddForBranchKey {
+    BNCServerInterface *serverInterface = [[BNCServerInterface alloc] init];
+    id urlConnectionMock = OCMClassMock([NSURLConnection class]);
+    
+    // Expect the query to contain branch key
+    [[urlConnectionMock expect] sendAsynchronousRequest:[OCMArg checkWithBlock:^BOOL(NSURLRequest *request) {
+        return [request.URL.query rangeOfString:@"branch_key=key_foo"].location != NSNotFound;
+    }] queue:[OCMArg any] completionHandler:[OCMArg any]];
+    
+    // Make the request
+    [serverInterface getRequest:nil url:@"http://foo" key:@"key_foo" callback:NULL];
+    
+    [urlConnectionMock verify];
+}
+
+- (void)testParamAddForAppKey {
+    BNCServerInterface *serverInterface = [[BNCServerInterface alloc] init];
+    id urlConnectionMock = OCMClassMock([NSURLConnection class]);
+    
+    // Expect the query to contain app id
+    [[urlConnectionMock expect] sendAsynchronousRequest:[OCMArg checkWithBlock:^BOOL(NSURLRequest *request) {
+        return [request.URL.query rangeOfString:@"app_id=non_branch_key"].location != NSNotFound;
+    }] queue:[OCMArg any] completionHandler:[OCMArg any]];
+    
+    // Make the request
+    [serverInterface getRequest:nil url:@"http://foo" key:@"non_branch_key" callback:NULL];
+    
+    [urlConnectionMock verify];
+}
+
+
 #pragma mark - Retry tests
 
 - (void)testGetRequestAsyncRetriesWhenAppropriate {

--- a/Branch-TestBed/Branch-SDK Functionality Tests/BranchNetworkScenarioTests.m
+++ b/Branch-TestBed/Branch-SDK Functionality Tests/BranchNetworkScenarioTests.m
@@ -40,7 +40,7 @@
 - (void)testScenario1 {
     id serverInterfaceMock = OCMClassMock([BranchServerInterface class]);
     
-    Branch *branch = [[Branch alloc] initWithInterface:serverInterfaceMock queue:[[BNCServerRequestQueue alloc] init] cache:[[BNCLinkCache alloc] init]];
+    Branch *branch = [[Branch alloc] initWithInterface:serverInterfaceMock queue:[[BNCServerRequestQueue alloc] init] cache:[[BNCLinkCache alloc] init] key:@"key_live"];
     [branch setAppListCheckEnabled:NO];
 
     XCTestExpectation *scenario1Expectation1 = [self expectationWithDescription:@"Scenario1 Expectation1"];
@@ -83,7 +83,7 @@
 - (void)testScenario2 {
     id serverInterfaceMock = OCMClassMock([BranchServerInterface class]);
     
-    Branch *branch = [[Branch alloc] initWithInterface:serverInterfaceMock queue:[[BNCServerRequestQueue alloc] init] cache:[[BNCLinkCache alloc] init]];
+    Branch *branch = [[Branch alloc] initWithInterface:serverInterfaceMock queue:[[BNCServerRequestQueue alloc] init] cache:[[BNCLinkCache alloc] init] key:@"key_foo"];
     [branch setAppListCheckEnabled:NO];
 
     XCTestExpectation *scenario2Expectation1 = [self expectationWithDescription:@"Scenario2 Expectation1"];
@@ -133,7 +133,7 @@
 - (void)testScenario3 {
     id serverInterfaceMock = OCMClassMock([BranchServerInterface class]);
     
-    Branch *branch = [[Branch alloc] initWithInterface:serverInterfaceMock queue:[[BNCServerRequestQueue alloc] init] cache:[[BNCLinkCache alloc] init]];
+    Branch *branch = [[Branch alloc] initWithInterface:serverInterfaceMock queue:[[BNCServerRequestQueue alloc] init] cache:[[BNCLinkCache alloc] init] key:@"key_foo"];
     [branch setAppListCheckEnabled:NO];
 
     XCTestExpectation *scenario3Expectation1 = [self expectationWithDescription:@"Scenario3 Expectation1"];
@@ -176,7 +176,7 @@
 - (void)testScenario4 {
     id serverInterfaceMock = OCMClassMock([BranchServerInterface class]);
     
-    Branch *branch = [[Branch alloc] initWithInterface:serverInterfaceMock queue:[[BNCServerRequestQueue alloc] init] cache:[[BNCLinkCache alloc] init]];
+    Branch *branch = [[Branch alloc] initWithInterface:serverInterfaceMock queue:[[BNCServerRequestQueue alloc] init] cache:[[BNCLinkCache alloc] init] key:@"key_foo"];
     [branch setAppListCheckEnabled:NO];
 
     XCTestExpectation *scenario4Expectation1 = [self expectationWithDescription:@"Scenario4 Expectation1"];
@@ -237,8 +237,8 @@
         openOrInstallCallback(nil, [NSError errorWithDomain:NSURLErrorDomain code:-1004 userInfo:nil]);
     };
 
-    [[[serverInterfaceMock stub] andDo:openOrInstallInvocation] registerInstall:NO callback:openOrInstallCallbackCheckBlock];
-    [[[serverInterfaceMock stub] andDo:openOrInstallInvocation] registerOpen:NO callback:openOrInstallCallbackCheckBlock];
+    [[[serverInterfaceMock stub] andDo:openOrInstallInvocation] registerInstall:NO key:[OCMArg any] callback:openOrInstallCallbackCheckBlock];
+    [[[serverInterfaceMock stub] andDo:openOrInstallInvocation] registerOpen:NO key:[OCMArg any] callback:openOrInstallCallbackCheckBlock];
     
     [branch initSessionAndRegisterDeepLinkHandler:[self callbackExpectingFailure:callback]];
 }
@@ -254,7 +254,7 @@
         badRequestCallback(nil, [NSError errorWithDomain:NSURLErrorDomain code:-1004 userInfo:nil]);
     };
     
-    [[[serverInterfaceMock expect] andDo:badRequestInvocation] getReferralCountsWithCallback:badRequestCheckBlock];
+    [[[serverInterfaceMock expect] andDo:badRequestInvocation] getReferralCountsWithKey:[OCMArg any] callback:badRequestCheckBlock];
     
     [branch loadActionCountsWithCallback:^(BOOL changed, NSError *error) {
         XCTAssertNotNil(error);
@@ -276,7 +276,7 @@
         goodRequestCallback(goodResponse, nil);
     };
     
-    [[[serverInterfaceMock expect] andDo:goodRequestInvocation] getReferralCountsWithCallback:goodRequestCheckBlock];
+    [[[serverInterfaceMock expect] andDo:goodRequestInvocation] getReferralCountsWithKey:[OCMArg any] callback:goodRequestCheckBlock];
     
     [branch loadActionCountsWithCallback:^(BOOL changed, NSError *error) {
         XCTAssertNil(error);
@@ -330,8 +330,8 @@
         openOrInstallCallback(openInstallResponse, nil);
     };
     
-    [[[serverInterfaceMock stub] andDo:openOrInstallInvocation] registerInstall:NO callback:openOrInstallCallbackCheckBlock];
-    [[[serverInterfaceMock stub] andDo:openOrInstallInvocation] registerOpen:NO callback:openOrInstallCallbackCheckBlock];
+    [[[serverInterfaceMock stub] andDo:openOrInstallInvocation] registerInstall:NO key:[OCMArg any] callback:openOrInstallCallbackCheckBlock];
+    [[[serverInterfaceMock stub] andDo:openOrInstallInvocation] registerOpen:NO key:[OCMArg any] callback:openOrInstallCallbackCheckBlock];
 }
 
 - (void)overrideBranch:(Branch *)branch initHandler:(callbackWithParams)initHandler {

--- a/Branch-TestBed/Branch-SDK Functionality Tests/Branch_SDK_Functionality_Tests.m
+++ b/Branch-TestBed/Branch-SDK Functionality Tests/Branch_SDK_Functionality_Tests.m
@@ -41,7 +41,7 @@ NSInteger const  TEST_CREDITS = 30;
 - (void)test00OpenOrInstall {
     id serverInterfaceMock = OCMClassMock([BranchServerInterface class]);
     
-    Branch *branch = [[Branch alloc] initWithInterface:serverInterfaceMock queue:[[BNCServerRequestQueue alloc] init] cache:[[BNCLinkCache alloc] init]];
+    Branch *branch = [[Branch alloc] initWithInterface:serverInterfaceMock queue:[[BNCServerRequestQueue alloc] init] cache:[[BNCLinkCache alloc] init] key:[OCMArg any]];
     [branch setAppListCheckEnabled:NO];
     
     [BNCPreferenceHelper setCreditCount:NSIntegerMax forBucket:@"default"];
@@ -65,8 +65,8 @@ NSInteger const  TEST_CREDITS = 30;
         openOrInstallCallback(openInstallResponse, nil);
     };
     
-    [[[serverInterfaceMock stub] andDo:openOrInstallInvocation] registerInstall:NO callback:openOrInstallCallbackCheckBlock];
-    [[[serverInterfaceMock stub] andDo:openOrInstallInvocation] registerOpen:NO callback:openOrInstallCallbackCheckBlock];
+    [[[serverInterfaceMock stub] andDo:openOrInstallInvocation] registerInstall:NO key:[OCMArg any] callback:openOrInstallCallbackCheckBlock];
+    [[[serverInterfaceMock stub] andDo:openOrInstallInvocation] registerOpen:NO key:[OCMArg any] callback:openOrInstallCallbackCheckBlock];
 
     // Fake branch key
     id preferenceHelperMock = OCMClassMock([BNCPreferenceHelper class]);
@@ -88,7 +88,7 @@ NSInteger const  TEST_CREDITS = 30;
     id serverInterfaceMock = OCMClassMock([BranchServerInterface class]);
     [self setupDefaultStubsForServerInterfaceMock:serverInterfaceMock];
     
-    Branch *branch = [[Branch alloc] initWithInterface:serverInterfaceMock queue:[[BNCServerRequestQueue alloc] init] cache:[[BNCLinkCache alloc] init]];
+    Branch *branch = [[Branch alloc] initWithInterface:serverInterfaceMock queue:[[BNCServerRequestQueue alloc] init] cache:[[BNCLinkCache alloc] init] key:[OCMArg any]];
     [branch setAppListCheckEnabled:NO];
     
     // mock logout synchronously
@@ -111,7 +111,7 @@ NSInteger const  TEST_CREDITS = 30;
     __block BNCServerCallback setIdentityCallback;
     [[[serverInterfaceMock expect] andDo:^(NSInvocation *invocation) {
         setIdentityCallback(setIdentityResponse, nil);
-    }] identifyUser:[OCMArg any] callback:[OCMArg checkWithBlock:^BOOL(BNCServerCallback callback) {
+    }] identifyUser:[OCMArg any] key:[OCMArg any] callback:[OCMArg checkWithBlock:^BOOL(BNCServerCallback callback) {
         setIdentityCallback = callback;
         return YES;
     }]];
@@ -140,7 +140,7 @@ NSInteger const  TEST_CREDITS = 30;
     id serverInterfaceMock = OCMClassMock([BranchServerInterface class]);
     [self setupDefaultStubsForServerInterfaceMock:serverInterfaceMock];
     
-    Branch *branch = [[Branch alloc] initWithInterface:serverInterfaceMock queue:[[BNCServerRequestQueue alloc] init] cache:[[BNCLinkCache alloc] init]];
+    Branch *branch = [[Branch alloc] initWithInterface:serverInterfaceMock queue:[[BNCServerRequestQueue alloc] init] cache:[[BNCLinkCache alloc] init] key:@"key_foo"];
     [branch setAppListCheckEnabled:NO];
 
     BNCServerResponse *fbLinkResponse = [[BNCServerResponse alloc] init];
@@ -152,18 +152,18 @@ NSInteger const  TEST_CREDITS = 30;
     __block BNCServerCallback fbCallback;
     [[[serverInterfaceMock expect] andDo:^(NSInvocation *invocation) {
         fbCallback(fbLinkResponse, nil);
-    }] createCustomUrl:[OCMArg any] callback:[OCMArg checkWithBlock:^BOOL(BNCServerCallback callback) {
+    }] createCustomUrl:[OCMArg any] key:[OCMArg any] callback:[OCMArg checkWithBlock:^BOOL(BNCServerCallback callback) {
         fbCallback = callback;
         return YES;
     }]];
     
     [[serverInterfaceMock reject] createCustomUrl:[OCMArg checkWithBlock:^BOOL(BNCServerRequest *request) {
         return [request.postData[@"channel"] isEqualToString:@"facebook"];
-    }]];
+    }] key:[OCMArg any]];
     
     [[[serverInterfaceMock expect] andReturn:twLinkResponse] createCustomUrl:[OCMArg checkWithBlock:^BOOL(BNCServerRequest *request) {
         return [request.postData[@"channel"] isEqualToString:@"twitter"];
-    }]];
+    }] key:[OCMArg any]];
     
     XCTestExpectation *getShortURLExpectation = [self expectationWithDescription:@"Test getShortURL"];
     
@@ -198,7 +198,7 @@ NSInteger const  TEST_CREDITS = 30;
     id serverInterfaceMock = OCMClassMock([BranchServerInterface class]);
     [self setupDefaultStubsForServerInterfaceMock:serverInterfaceMock];
     
-    Branch *branch = [[Branch alloc] initWithInterface:serverInterfaceMock queue:[[BNCServerRequestQueue alloc] init] cache:[[BNCLinkCache alloc] init]];
+    Branch *branch = [[Branch alloc] initWithInterface:serverInterfaceMock queue:[[BNCServerRequestQueue alloc] init] cache:[[BNCLinkCache alloc] init] key:@"key_foo"];
     [branch setAppListCheckEnabled:NO];
 
     XCTestExpectation *getShortURLExpectation = [self expectationWithDescription:@"Test getShortURL Sync"];
@@ -212,16 +212,16 @@ NSInteger const  TEST_CREDITS = 30;
         // FB should only be called once
         [[[serverInterfaceMock expect] andReturn:fbLinkResponse] createCustomUrl:[OCMArg checkWithBlock:^BOOL(BNCServerRequest *request) {
             return [request.postData[@"channel"] isEqualToString:@"facebook"];
-        }]];
+        }] key:[OCMArg any]];
         
         [[serverInterfaceMock reject] createCustomUrl:[OCMArg checkWithBlock:^BOOL(BNCServerRequest *request) {
             return [request.postData[@"channel"] isEqualToString:@"facebook"];
-        }]];
+        }] key:[OCMArg any]];
         
         // TW should be allowed still
         [[[serverInterfaceMock expect] andReturn:twLinkResponse] createCustomUrl:[OCMArg checkWithBlock:^BOOL(BNCServerRequest *request) {
             return [request.postData[@"channel"] isEqualToString:@"twitter"];
-        }]];
+        }] key:[OCMArg any]];
         
         NSString *url1 = [branch getShortURLWithParams:nil andChannel:@"facebook" andFeature:nil];
         XCTAssertNotNil(url1);
@@ -245,7 +245,7 @@ NSInteger const  TEST_CREDITS = 30;
     id serverInterfaceMock = OCMClassMock([BranchServerInterface class]);
     [self setupDefaultStubsForServerInterfaceMock:serverInterfaceMock];
     
-    Branch *branch = [[Branch alloc] initWithInterface:serverInterfaceMock queue:[[BNCServerRequestQueue alloc] init] cache:[[BNCLinkCache alloc] init]];
+    Branch *branch = [[Branch alloc] initWithInterface:serverInterfaceMock queue:[[BNCServerRequestQueue alloc] init] cache:[[BNCLinkCache alloc] init] key:@"key_foo"];
     [branch setAppListCheckEnabled:NO];
 
     [BNCPreferenceHelper setCreditCount:NSIntegerMax forBucket:@"default"];
@@ -256,7 +256,7 @@ NSInteger const  TEST_CREDITS = 30;
     __block BNCServerCallback loadCreditsCallback;
     [[[serverInterfaceMock expect] andDo:^(NSInvocation *invocation) {
         loadCreditsCallback(loadCreditsResponse, nil);
-    }] getRewardsWithCallback:[OCMArg checkWithBlock:^BOOL(BNCServerCallback callback) {
+    }] getRewardsWithKey:[OCMArg any] callback:[OCMArg checkWithBlock:^BOOL(BNCServerCallback callback) {
         loadCreditsCallback = callback;
         return YES;
     }]];
@@ -277,7 +277,7 @@ NSInteger const  TEST_CREDITS = 30;
     id serverInterfaceMock = OCMClassMock([BranchServerInterface class]);
     [self setupDefaultStubsForServerInterfaceMock:serverInterfaceMock];
     
-    Branch *branch = [[Branch alloc] initWithInterface:serverInterfaceMock queue:[[BNCServerRequestQueue alloc] init] cache:[[BNCLinkCache alloc] init]];
+    Branch *branch = [[Branch alloc] initWithInterface:serverInterfaceMock queue:[[BNCServerRequestQueue alloc] init] cache:[[BNCLinkCache alloc] init] key:@"key_foo"];
     [branch setAppListCheckEnabled:NO];
 
     [BNCPreferenceHelper setCreditCount:1 forBucket:@"default"];
@@ -288,7 +288,7 @@ NSInteger const  TEST_CREDITS = 30;
     __block BNCServerCallback loadRewardsCallback;
     [[[serverInterfaceMock expect] andDo:^(NSInvocation *invocation) {
         loadRewardsCallback(loadRewardsResponse, nil);
-    }] getRewardsWithCallback:[OCMArg checkWithBlock:^BOOL(BNCServerCallback callback) {
+    }] getRewardsWithKey:[OCMArg any] callback:[OCMArg checkWithBlock:^BOOL(BNCServerCallback callback) {
         loadRewardsCallback = callback;
         return YES;
     }]];
@@ -309,7 +309,7 @@ NSInteger const  TEST_CREDITS = 30;
     id serverInterfaceMock = OCMClassMock([BranchServerInterface class]);
     [self setupDefaultStubsForServerInterfaceMock:serverInterfaceMock];
     
-    Branch *branch = [[Branch alloc] initWithInterface:serverInterfaceMock queue:[[BNCServerRequestQueue alloc] init] cache:[[BNCLinkCache alloc] init]];
+    Branch *branch = [[Branch alloc] initWithInterface:serverInterfaceMock queue:[[BNCServerRequestQueue alloc] init] cache:[[BNCLinkCache alloc] init] key:@"key_foo"];
     [branch setAppListCheckEnabled:NO];
 
     [BNCPreferenceHelper setCreditCount:1 forBucket:@"default"];
@@ -338,7 +338,7 @@ NSInteger const  TEST_CREDITS = 30;
     __block BNCServerCallback referralCodeCallback;
     [[[serverInterfaceMock expect] andDo:^(NSInvocation *invocation) {
         referralCodeCallback(referralCodeResponse, nil);
-    }] getReferralCode:[OCMArg any] callback:[OCMArg checkWithBlock:^BOOL(BNCServerCallback callback) {
+    }] getReferralCode:[OCMArg any] key:[OCMArg any] callback:[OCMArg checkWithBlock:^BOOL(BNCServerCallback callback) {
         referralCodeCallback = callback;
         return YES;
     }]];
@@ -358,7 +358,7 @@ NSInteger const  TEST_CREDITS = 30;
     id serverInterfaceMock = OCMClassMock([BranchServerInterface class]);
     [self setupDefaultStubsForServerInterfaceMock:serverInterfaceMock];
     
-    Branch *branch = [[Branch alloc] initWithInterface:serverInterfaceMock queue:[[BNCServerRequestQueue alloc] init] cache:[[BNCLinkCache alloc] init]];
+    Branch *branch = [[Branch alloc] initWithInterface:serverInterfaceMock queue:[[BNCServerRequestQueue alloc] init] cache:[[BNCLinkCache alloc] init] key:@"key_foo"];
     [branch setAppListCheckEnabled:NO];
 
     [BNCPreferenceHelper setCreditCount:1 forBucket:@"default"];
@@ -387,7 +387,7 @@ NSInteger const  TEST_CREDITS = 30;
     __block BNCServerCallback validateCodeCallback;
     [[[serverInterfaceMock expect] andDo:^(NSInvocation *invocation) {
         validateCodeCallback(validateCodeResponse, nil);
-    }] validateReferralCode:[OCMArg any] callback:[OCMArg checkWithBlock:^BOOL(BNCServerCallback callback) {
+    }] validateReferralCode:[OCMArg any] key:[OCMArg any] callback:[OCMArg checkWithBlock:^BOOL(BNCServerCallback callback) {
         validateCodeCallback = callback;
         return YES;
     }]];
@@ -413,7 +413,7 @@ NSInteger const  TEST_CREDITS = 30;
     id serverInterfaceMock = OCMClassMock([BranchServerInterface class]);
     [self setupDefaultStubsForServerInterfaceMock:serverInterfaceMock];
     
-    Branch *branch = [[Branch alloc] initWithInterface:serverInterfaceMock queue:[[BNCServerRequestQueue alloc] init] cache:[[BNCLinkCache alloc] init]];
+    Branch *branch = [[Branch alloc] initWithInterface:serverInterfaceMock queue:[[BNCServerRequestQueue alloc] init] cache:[[BNCLinkCache alloc] init] key:@"key_foo"];
     [branch setAppListCheckEnabled:NO];
 
     [BNCPreferenceHelper setCreditCount:1 forBucket:@"default"];
@@ -442,7 +442,7 @@ NSInteger const  TEST_CREDITS = 30;
     __block BNCServerCallback applyCodeCallback;
     [[[serverInterfaceMock expect] andDo:^(NSInvocation *invocation) {
         applyCodeCallback(applyCodeResponse, nil);
-    }] applyReferralCode:[OCMArg any] callback:[OCMArg checkWithBlock:^BOOL(BNCServerCallback callback) {
+    }] applyReferralCode:[OCMArg any] key:[OCMArg any] callback:[OCMArg checkWithBlock:^BOOL(BNCServerCallback callback) {
         applyCodeCallback = callback;
         return YES;
     }]];
@@ -468,7 +468,7 @@ NSInteger const  TEST_CREDITS = 30;
     id serverInterfaceMock = OCMClassMock([BranchServerInterface class]);
     [self setupDefaultStubsForServerInterfaceMock:serverInterfaceMock];
     
-    Branch *branch = [[Branch alloc] initWithInterface:serverInterfaceMock queue:[[BNCServerRequestQueue alloc] init] cache:[[BNCLinkCache alloc] init]];
+    Branch *branch = [[Branch alloc] initWithInterface:serverInterfaceMock queue:[[BNCServerRequestQueue alloc] init] cache:[[BNCLinkCache alloc] init] key:@"key_foo"];
     [branch setAppListCheckEnabled:NO];
 
     [BNCPreferenceHelper setCreditCount:1 forBucket:@"default"];
@@ -491,7 +491,7 @@ NSInteger const  TEST_CREDITS = 30;
     __block BNCServerCallback creditHistoryCallback;
     [[[serverInterfaceMock expect] andDo:^(NSInvocation *invocation) {
         creditHistoryCallback(creditHistoryResponse, nil);
-    }] getCreditHistory:[OCMArg any] callback:[OCMArg checkWithBlock:^BOOL(BNCServerCallback callback) {
+    }] getCreditHistory:[OCMArg any] key:[OCMArg any] callback:[OCMArg checkWithBlock:^BOOL(BNCServerCallback callback) {
         creditHistoryCallback = callback;
         return YES;
     }]];
@@ -544,8 +544,8 @@ NSInteger const  TEST_CREDITS = 30;
         openOrInstallCallback(openInstallResponse, nil);
     };
     
-    [[[serverInterfaceMock stub] andDo:openOrInstallInvocation] registerInstall:NO callback:openOrInstallCallbackCheckBlock];
-    [[[serverInterfaceMock stub] andDo:openOrInstallInvocation] registerOpen:NO callback:openOrInstallCallbackCheckBlock];
+    [[[serverInterfaceMock stub] andDo:openOrInstallInvocation] registerInstall:NO key:[OCMArg any] callback:openOrInstallCallbackCheckBlock];
+    [[[serverInterfaceMock stub] andDo:openOrInstallInvocation] registerOpen:NO key:[OCMArg any] callback:openOrInstallCallbackCheckBlock];
     
     // Fake branch key
     id preferenceHelperMock = OCMClassMock([BNCPreferenceHelper class]);

--- a/Branch-TestBed/Branch-SDK Load Tests/Branch_SDK_Load_Tests.m
+++ b/Branch-TestBed/Branch-SDK Load Tests/Branch_SDK_Load_Tests.m
@@ -24,7 +24,7 @@
     id preferenceHelperMock = OCMClassMock([BNCPreferenceHelper class]);
     id serverInterfaceMock = OCMClassMock([BranchServerInterface class]);
 
-    Branch *branch = [[Branch alloc] initWithInterface:serverInterfaceMock queue:[[BNCServerRequestQueue alloc] init] cache:[[BNCLinkCache alloc] init]];
+    Branch *branch = [[Branch alloc] initWithInterface:serverInterfaceMock queue:[[BNCServerRequestQueue alloc] init] cache:[[BNCLinkCache alloc] init] key:@"key_foo"];
     [branch setAppListCheckEnabled:NO];
     
     BNCServerResponse *linkResponse = [[BNCServerResponse alloc] init];
@@ -45,7 +45,7 @@
     __block BNCServerCallback urlCallback;
     [[[serverInterfaceMock stub] andDo:^(NSInvocation *invocation) {
         urlCallback(linkResponse, nil);
-    }] createCustomUrl:[OCMArg any] callback:[OCMArg checkWithBlock:^BOOL(BNCServerCallback callback) {
+    }] createCustomUrl:[OCMArg any] key:[OCMArg any] callback:[OCMArg checkWithBlock:^BOOL(BNCServerCallback callback) {
         urlCallback = callback;
         return YES;
     }]];
@@ -55,8 +55,8 @@
         return YES;
     }];
     
-    [[serverInterfaceMock stub] registerInstall:NO callback:openOrInstallCallbackCheckBlock];
-    [[serverInterfaceMock stub] registerOpen:NO callback:openOrInstallCallbackCheckBlock];
+    [[serverInterfaceMock stub] registerInstall:NO key:[OCMArg any] callback:openOrInstallCallbackCheckBlock];
+    [[serverInterfaceMock stub] registerOpen:NO key:[OCMArg any] callback:openOrInstallCallbackCheckBlock];
     
     // Fake branch key
     [[[preferenceHelperMock stub] andReturn:@"foo"] getBranchKey];


### PR DESCRIPTION
@aaustin @derrickstaten @qinweigong @Sarkar 

Rather than letting BNCServerInterface choose a key, it should be provided with one for each request.
This means adding key to all the methods (yay, more injection).
Prior to this change, when trying to use test mode, the server interface would never have actually sent the test key.
Not entirely confident that the Preference helper is doing this right, but that's going to be another change.

Also removed some unused methods from the BranchServerInterface.
Consolidated param prep within BNCServerInterface into a single method.