### PR TITLE
Rework debug logic

### DIFF
--- a/Branch-SDK/Branch-SDK/BNCPreferenceHelper.h
+++ b/Branch-SDK/Branch-SDK/BNCPreferenceHelper.h
@@ -16,7 +16,7 @@ static NSString *NO_STRING_VALUE = @"bnc_no_value";
 
 @protocol BNCDebugConnectionDelegate <NSObject>
 
-- (void)bnc_debugConnectionEstablished;
+- (void)debugConnectionEstablished;
 
 @end
 
@@ -28,6 +28,8 @@ static NSString *NO_STRING_VALUE = @"bnc_no_value";
 
 @interface BNCPreferenceHelper : NSObject
 
+@property (assign, nonatomic) BOOL isDebugMode;
+@property (assign, nonatomic) BOOL isConnectedToRemoteDebug;
 @property (assign, nonatomic) NSInteger retryCount;
 @property (assign, nonatomic) NSInteger retryInterval;
 @property (assign, nonatomic) NSInteger timeout;
@@ -103,11 +105,10 @@ static NSString *NO_STRING_VALUE = @"bnc_no_value";
 + (NSInteger)getActionTotalCount:(NSString *)action;
 + (NSInteger)getActionUniqueCount:(NSString *)action;
 
-+ (void)setDevDebug;
-+ (BOOL)getDevDebug;
 + (void)setDebug;
-+ (void)clearDebug;
 + (BOOL)isDebug;
++ (void)connectRemoteDebug;
++ (void)disconnectRemoteDebug;
 + (void)log:(NSString *)filename line:(int)line message:(NSString *)format, ...;
 + (void)sendScreenshot:(NSData *)data;
 + (void)setDebugConnectionDelegate:(id<BNCDebugConnectionDelegate>) debugConnectionDelegate;

--- a/Branch-SDK/Branch-SDK/BNCPreferenceHelper.h
+++ b/Branch-SDK/Branch-SDK/BNCPreferenceHelper.h
@@ -106,6 +106,7 @@ static NSString *NO_STRING_VALUE = @"bnc_no_value";
 + (NSInteger)getActionUniqueCount:(NSString *)action;
 
 + (void)setDebug;
++ (void)clearDebug;
 + (BOOL)isDebug;
 + (void)connectRemoteDebug;
 + (void)disconnectRemoteDebug;

--- a/Branch-SDK/Branch-SDK/BNCPreferenceHelper.m
+++ b/Branch-SDK/Branch-SDK/BNCPreferenceHelper.m
@@ -79,6 +79,12 @@ static NSString *Branch_Key = nil;
     [BNCPreferenceHelper getInstance].isDebugMode = YES;
 }
 
++ (void)clearDebug {
+    [BNCPreferenceHelper getInstance].isDebugMode = NO;
+    
+    [self disconnectRemoteDebug];
+}
+
 + (void)connectRemoteDebug {
     serverInterface = [[BranchServerInterface alloc] init];
     bnc_asyncLogQueue = dispatch_queue_create("bnc_log_queue", NULL);

--- a/Branch-SDK/Branch-SDK/BNCPreferenceHelper.m
+++ b/Branch-SDK/Branch-SDK/BNCPreferenceHelper.m
@@ -38,10 +38,6 @@ static NSString *KEY_COUNTS = @"bnc_counts";
 static NSString *KEY_TOTAL_BASE = @"bnc_total_base_";
 static NSString *KEY_UNIQUE_BASE = @"bnc_unique_base_";
 
-static BOOL BNC_Debug = NO;
-static BOOL BNC_Dev_Debug = NO;
-static BOOL BNC_Remote_Debug = NO;
-
 static dispatch_queue_t bnc_asyncLogQueue = nil;
 static id<BNCDebugConnectionDelegate> bnc_asyncDebugConnectionDelegate = nil;
 static BranchServerInterface *serverInterface = nil;
@@ -57,6 +53,9 @@ static NSString *Branch_Key = nil;
         _timeout = DEFAULT_TIMEOUT;
         _retryCount = DEFAULT_RETRY_COUNT;
         _retryInterval = DEFAULT_RETRY_INTERVAL;
+        
+        _isDebugMode = NO;
+        _isConnectedToRemoteDebug = NO;
     }
     
     return self;
@@ -73,9 +72,14 @@ static NSString *Branch_Key = nil;
     return preferenceHelper;
 }
 
+
+#pragma mark - Debug methods
+
 + (void)setDebug {
-    BNC_Debug = YES;
-    
+    [BNCPreferenceHelper getInstance].isDebugMode = YES;
+}
+
++ (void)connectRemoteDebug {
     serverInterface = [[BranchServerInterface alloc] init];
     bnc_asyncLogQueue = dispatch_queue_create("bnc_log_queue", NULL);
 
@@ -84,60 +88,52 @@ static NSString *Branch_Key = nil;
             NSLog(@"Failed to connect to debug: %@", error);
         }
         else {
-            BNC_Remote_Debug = YES;
-            [bnc_asyncDebugConnectionDelegate bnc_debugConnectionEstablished];
+            [BNCPreferenceHelper getInstance].isConnectedToRemoteDebug = YES;
+            [bnc_asyncDebugConnectionDelegate debugConnectionEstablished];
         }
     }];
 }
 
-+ (void)setDevDebug {
-    BNC_Dev_Debug = YES;
-}
-
-+ (BOOL)getDevDebug {
-    return BNC_Dev_Debug;
-}
-
-+ (void)clearDebug {
-    BNC_Debug = NO;
-    
-    if (BNC_Remote_Debug) {
-        BNC_Remote_Debug = NO;
++ (void)disconnectRemoteDebug {
+    BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper getInstance];
+    if (preferenceHelper.isConnectedToRemoteDebug) {
+        preferenceHelper.isConnectedToRemoteDebug = NO;
         
         [serverInterface disconnectFromDebugWithCallback:NULL];
     }
 }
 
 + (BOOL)isDebug {
-    return BNC_Debug;
+    return [BNCPreferenceHelper getInstance].isDebugMode;
 }
 
 + (BOOL)isRemoteDebug {
-    return BNC_Remote_Debug;
+    return [BNCPreferenceHelper getInstance].isConnectedToRemoteDebug;
 }
 
 + (void)log:(NSString *)filename line:(int)line message:(NSString *)format, ... {
-    if (BNC_Debug || BNC_Dev_Debug) {
+    if ([BNCPreferenceHelper getInstance].isDebugMode) {
         va_list args;
         va_start(args, format);
         NSString *log = [NSString stringWithFormat:@"[%@:%d] %@", filename, line, [[NSString alloc] initWithFormat:format arguments:args]];
         va_end(args);
         NSLog(@"%@", log);
         
-        if (BNC_Remote_Debug) {
+        if ([BNCPreferenceHelper getInstance].isConnectedToRemoteDebug) {
             [serverInterface sendLog:log callback:NULL];
         }
     }
 }
 
 + (void)keepDebugAlive {
-    if (BNC_Remote_Debug) {
+    if ([BNCPreferenceHelper getInstance].isConnectedToRemoteDebug) {
+        NSLog(@"[Branch Debug] Sending Keep Alive");
         [serverInterface sendLog:@"" callback:NULL];
     }
 }
 
 + (void)sendScreenshot:(NSData *)data {
-    if (BNC_Remote_Debug) {
+    if ([BNCPreferenceHelper getInstance].isConnectedToRemoteDebug) {
         [serverInterface sendScreenshot:data callback:NULL];
     }
 }

--- a/Branch-SDK/Branch-SDK/Branch.h
+++ b/Branch-SDK/Branch-SDK/Branch.h
@@ -239,7 +239,7 @@ typedef NS_ENUM(NSUInteger, BranchReferralCodeCalculation) {
  
  @warning This should not be used in production.
  */
-+ (void)setDebug;
+- (void)setDebug;
 
 /**
  Specify the time to wait in seconds between retries in the case of a Branch server error

--- a/Branch-SDK/Branch-SDK/Branch.h
+++ b/Branch-SDK/Branch-SDK/Branch.h
@@ -242,6 +242,14 @@ typedef NS_ENUM(NSUInteger, BranchReferralCodeCalculation) {
 - (void)setDebug;
 
 /**
+ Have Branch treat this device / session as a debug session, causing more information to be logged, and info to be available in the debug tab of the dashboard.
+ 
+ @warning Deprecated, use the instance method.
+ @warning This should not be used in production.
+ */
++ (void)setDebug __attribute__((deprecated(("Use the instance method instead"))));
+
+/**
  Specify the time to wait in seconds between retries in the case of a Branch server error
  
  @param retryInterval Number of seconds to wait between retries.

--- a/Branch-SDK/Branch-SDK/Branch.m
+++ b/Branch-SDK/Branch-SDK/Branch.m
@@ -215,6 +215,10 @@ static int BNCDebugTriggerFingersSimulator = 2;
 
 #pragma mark - Configuration methods
 
++ (void)setDebug {
+    [[Branch getInstance] setDebug];
+}
+
 - (void)setDebug {
     [BNCPreferenceHelper setDebug];
 }

--- a/Branch-SDK/Branch-SDK/Branch.m
+++ b/Branch-SDK/Branch-SDK/Branch.m
@@ -215,7 +215,7 @@ static int BNCDebugTriggerFingersSimulator = 2;
 
 #pragma mark - Configuration methods
 
-+ (void)setDebug {
+- (void)setDebug {
     [BNCPreferenceHelper setDebug];
 }
 

--- a/Branch-SDK/Branch-SDK/Branch.m
+++ b/Branch-SDK/Branch-SDK/Branch.m
@@ -64,9 +64,6 @@ NSInteger REFERRAL_CREATION_SOURCE_SDK = 2;
 static int BNCDebugTriggerDuration = 3;
 static int BNCDebugTriggerFingers = 4;
 static int BNCDebugTriggerFingersSimulator = 2;
-static dispatch_queue_t bnc_asyncDebugQueue = nil;
-static NSTimer *bnc_debugTimer = nil;
-static UILongPressGestureRecognizer *BNCLongPress = nil;
 
 
 #define DIRECTIONS @[@"desc", @"asc"]
@@ -86,6 +83,8 @@ static UILongPressGestureRecognizer *BNCLongPress = nil;
 @property (assign, nonatomic) BOOL shouldCallSessionInitCallback;
 @property (assign, nonatomic) BOOL appListCheckEnabled;
 @property (strong, nonatomic) BNCLinkCache *linkCache;
+@property (strong, nonatomic) UILongPressGestureRecognizer *debugGestureRecognizer;
+@property (strong, nonatomic) NSTimer *debugHeartbeatTimer;
 
 @end
 
@@ -217,7 +216,7 @@ static UILongPressGestureRecognizer *BNCLongPress = nil;
 #pragma mark - Configuration methods
 
 + (void)setDebug {
-    [BNCPreferenceHelper setDevDebug];
+    [BNCPreferenceHelper setDebug];
 }
 
 - (void)resetUserSession {
@@ -1213,7 +1212,7 @@ static UILongPressGestureRecognizer *BNCLongPress = nil;
         [self initUserSessionAndCallCallback:YES];
     }
     
-    [self bnc_addDebugGestureRecognizer];
+    [self addDebugGestureRecognizer];
 }
 
 - (void)applicationWillResignActive {
@@ -1221,8 +1220,8 @@ static UILongPressGestureRecognizer *BNCLongPress = nil;
     self.sessionTimer = [NSTimer scheduledTimerWithTimeInterval:0.5 target:self selector:@selector(callClose) userInfo:nil repeats:NO];
     [self.requestQueue persistImmediately];
     
-    if (BNCLongPress) {
-        [[UIApplication sharedApplication].keyWindow removeGestureRecognizer:BNCLongPress];
+    if (self.debugGestureRecognizer) {
+        [[UIApplication sharedApplication].keyWindow removeGestureRecognizer:self.debugGestureRecognizer];
     }
 }
 
@@ -1609,82 +1608,75 @@ static UILongPressGestureRecognizer *BNCLongPress = nil;
 
 #pragma mark - Debugger functions
 
-- (void)bnc_addDebugGestureRecognizer {
-    [self bnc_addGesterRecognizer:@selector(bnc_connectToDebug:)];
+- (void)addDebugGestureRecognizer {
+    [self addGesterRecognizer:@selector(connectToDebug:)];
 }
 
-- (void)bnc_addCancelDebugGestureRecognizer {
-    [self bnc_addGesterRecognizer:@selector(bnc_endDebug:)];
+- (void)addCancelDebugGestureRecognizer {
+    [self addGesterRecognizer:@selector(endRemoteDebugging:)];
 }
 
-- (void)bnc_addGesterRecognizer:(SEL)action {
-    BNCLongPress = [[UILongPressGestureRecognizer alloc] initWithTarget:self action:action];
-    BNCLongPress.delegate = self;
-    BNCLongPress.minimumPressDuration = BNCDebugTriggerDuration;
+- (void)addGesterRecognizer:(SEL)action {
+    UIWindow *window = [UIApplication sharedApplication].keyWindow;
+    [window removeGestureRecognizer:self.debugGestureRecognizer]; // Remove existing gesture
+    
+    self.debugGestureRecognizer = [[UILongPressGestureRecognizer alloc] initWithTarget:self action:action];
+    self.debugGestureRecognizer.delegate = self;
+    self.debugGestureRecognizer.minimumPressDuration = BNCDebugTriggerDuration;
+
     if ([BNCSystemObserver isSimulator]) {
-        BNCLongPress.numberOfTouchesRequired = BNCDebugTriggerFingersSimulator;
-    } else {
-        BNCLongPress.numberOfTouchesRequired = BNCDebugTriggerFingers;
+        self.debugGestureRecognizer.numberOfTouchesRequired = BNCDebugTriggerFingersSimulator;
     }
-    [[UIApplication sharedApplication].keyWindow addGestureRecognizer:BNCLongPress];
+    else {
+        self.debugGestureRecognizer.numberOfTouchesRequired = BNCDebugTriggerFingers;
+    }
+    
+    [window addGestureRecognizer:self.debugGestureRecognizer];
 }
 
-- (void)bnc_connectToDebug:(UILongPressGestureRecognizer *)sender {
+- (void)connectToDebug:(UILongPressGestureRecognizer *)sender {
     if (sender.state == UIGestureRecognizerStateBegan){
         NSLog(@"======= Start Debug Session =======");
         [BNCPreferenceHelper setDebugConnectionDelegate:self];
-        [BNCPreferenceHelper setDebug];
+        [BNCPreferenceHelper connectRemoteDebug];
     }
 }
 
-- (void)bnc_startDebug {
+- (void)startRemoteDebugging {
     NSLog(@"======= Connected to Branch Remote Debugger =======");
     
-    if (!bnc_asyncDebugQueue) {
-        bnc_asyncDebugQueue = dispatch_queue_create("bnc_debug_queue", NULL);
-    }
-    
-    [[UIApplication sharedApplication].keyWindow removeGestureRecognizer:BNCLongPress];
-    [self bnc_addCancelDebugGestureRecognizer];
+    [[UIApplication sharedApplication].keyWindow removeGestureRecognizer:self.debugGestureRecognizer];
+    [self addCancelDebugGestureRecognizer];
     
     //TODO: change to send screenshots instead in future
-    if (!bnc_debugTimer || !bnc_debugTimer.isValid) {
-        bnc_debugTimer = [NSTimer scheduledTimerWithTimeInterval:20.0f
-                                                          target:self
-                                                        selector:@selector(bnc_keepDebugAlive)     //change to @selector(bnc_takeScreenshot)
-                                                        userInfo:nil
-                                                         repeats:YES];
+    if (!self.debugHeartbeatTimer || !self.debugHeartbeatTimer.isValid) {
+        self.debugHeartbeatTimer = [NSTimer scheduledTimerWithTimeInterval:20 target:self selector:@selector(keepDebugAlive) userInfo:nil repeats:YES];
     }
 }
 
-- (void)bnc_endDebug:(UILongPressGestureRecognizer *)sender {
+- (void)endRemoteDebugging:(UILongPressGestureRecognizer *)sender {
     NSLog(@"======= End Debug Session =======");
     
     [[UIApplication sharedApplication].keyWindow removeGestureRecognizer:sender];
-    [BNCPreferenceHelper clearDebug];
-    bnc_asyncDebugQueue = nil;
-    [bnc_debugTimer invalidate];
-    [self bnc_addDebugGestureRecognizer];
+    [BNCPreferenceHelper disconnectRemoteDebug];
+    [self.debugHeartbeatTimer invalidate];
+    [self addDebugGestureRecognizer];
 }
 
-- (void)bnc_keepDebugAlive {
-    if (bnc_asyncDebugQueue) {
-        dispatch_async(bnc_asyncDebugQueue, ^{
-            [BNCPreferenceHelper keepDebugAlive];
-        });
-    }
+- (void)keepDebugAlive {
+    [BNCPreferenceHelper keepDebugAlive];
 }
 
 #pragma mark - BNCDebugConnectionDelegate
 
-- (void)bnc_debugConnectionEstablished {
-    [self bnc_startDebug];
+- (void)debugConnectionEstablished {
+    [self startRemoteDebugging];
 }
 
 #pragma mark - UIGestureRecognizerDelegate
 
 - (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer {
-        return YES;
+    return YES;
 }
 
 #pragma mark - BNCTestDelagate

--- a/Branch-SDK/Branch-SDK/BranchServerInterface.m
+++ b/Branch-SDK/Branch-SDK/BranchServerInterface.m
@@ -17,7 +17,7 @@
     NSMutableDictionary *post = [[NSMutableDictionary alloc] init];
     
     BOOL isRealHardwareId;
-    NSString *hardwareId = [BNCSystemObserver getUniqueHardwareId:&isRealHardwareId andIsDebug:[BNCPreferenceHelper getDevDebug]];
+    NSString *hardwareId = [BNCSystemObserver getUniqueHardwareId:&isRealHardwareId andIsDebug:[BNCPreferenceHelper isDebug]];
     if (hardwareId) {
         [post setObject:hardwareId forKey:@"hardware_id"];
         [post setObject:[NSNumber numberWithBool:isRealHardwareId] forKey:@"is_hardware_id_real"];
@@ -53,7 +53,7 @@
     
     if ([[BNCPreferenceHelper getDeviceFingerprintID] isEqualToString:NO_STRING_VALUE]) {
         BOOL isRealHardwareId;
-        NSString *hardwareId = [BNCSystemObserver getUniqueHardwareId:&isRealHardwareId andIsDebug:[BNCPreferenceHelper getDevDebug]];
+        NSString *hardwareId = [BNCSystemObserver getUniqueHardwareId:&isRealHardwareId andIsDebug:[BNCPreferenceHelper isDebug]];
         if (hardwareId) {
             [post setObject:hardwareId forKey:@"hardware_id"];
             [post setObject:[NSNumber numberWithBool:isRealHardwareId] forKey:@"is_hardware_id_real"];

--- a/Branch-TestBed/Branch-SDK Functionality Tests/BNCPreferenceHelperTests.m
+++ b/Branch-TestBed/Branch-SDK Functionality Tests/BNCPreferenceHelperTests.m
@@ -25,7 +25,7 @@
 
 + (void)tearDown {
     [[LSNocilla sharedInstance] stop];
-
+    
     [BNCPreferenceHelper clearDebug];
 
     [super tearDown];
@@ -42,7 +42,7 @@
     stubRequest(@"POST", [BNCPreferenceHelper getAPIURL:@"debug/connect"])
     .andReturn(200);
 
-    [BNCPreferenceHelper setDebug];
+    [BNCPreferenceHelper connectRemoteDebug];
     
     // Allow request to complete;
     [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:1]];
@@ -59,7 +59,7 @@
     .withHeaders(@{@"Content-Type": @"application/json"})
     .withBody(responseData);
 
-    [BNCPreferenceHelper setDebug];
+    [BNCPreferenceHelper connectRemoteDebug];
 
     [NSThread sleepForTimeInterval:1]; // Allow request to complete
     

--- a/Branch-TestBed/Branch-TestBed/AppDelegate.m
+++ b/Branch-TestBed/Branch-TestBed/AppDelegate.m
@@ -13,7 +13,7 @@
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
     Branch *branch = [Branch getInstance];
-    [Branch setDebug];
+    [branch setDebug];
     [branch initSessionWithLaunchOptions:launchOptions andRegisterDeepLinkHandler:^(NSDictionary *params, NSError *error) {
         if (!error) {
             NSLog(@"finished init with params = %@", [params description]);


### PR DESCRIPTION
@aaustin @derrickstaten @qinweigong @Sarkar 

Updating PreferenceHelper debug to only use two booleans, once indicating whether the app is in debug mode, when indicating with it is connected to remote debug.
Removing bnc_ prefixes from a bunch of methods in Branch.m.
Making all the variables related to debug instance variables (and setDebug an instance method).
Updating open/install debug checks to just use `isDebug`.