### PR TITLE
Expose Identity State

### DIFF
--- a/Branch-SDK/Branch-SDK/Branch.h
+++ b/Branch-SDK/Branch-SDK/Branch.h
@@ -299,6 +299,12 @@ typedef NS_ENUM(NSUInteger, BranchReferralCodeCalculation) {
 - (void)resetUserSession;
 
 /**
+ Indicates whether or not this user has a custom identity specified for them. Note that this is *independent of installs*. If you call setIdentity, this device
+ will have that identity associated with this user until `logout` is called. This includes persisting through uninstalls, as we track device id.
+ */
+- (BOOL)isUserIdentified;
+
+/**
  Set the user's identity to an ID used by your system, so that it is identifiable by you elsewhere.
  
  @param userId The ID Branch should use to identify this user.

--- a/Branch-SDK/Branch-SDK/Branch.m
+++ b/Branch-SDK/Branch-SDK/Branch.m
@@ -229,6 +229,10 @@ static int BNCDebugTriggerFingersSimulator = 2;
     self.isInitialized = NO;
 }
 
+- (BOOL)isUserIdentified {
+    return [BNCPreferenceHelper getUserIdentity] != nil;
+}
+
 - (void)setNetworkTimeout:(NSInteger)timeout {
     [BNCPreferenceHelper setTimeout:timeout];
 }
@@ -1589,6 +1593,10 @@ static int BNCDebugTriggerFingersSimulator = 2;
     
     if ([data objectForKey:BRANCH_DATA_KEY_IDENTITY_ID]) {
         [BNCPreferenceHelper setIdentityID:[data objectForKey:BRANCH_DATA_KEY_IDENTITY_ID]];
+    }
+    
+    if ([data objectForKey:BRANCH_DATA_KEY_IDENTITY]) {
+        [BNCPreferenceHelper setUserIdentity:[data objectForKey:BRANCH_DATA_KEY_IDENTITY]];
     }
     
     [self updateAllRequestsInQueue];


### PR DESCRIPTION
@aaustin @derrickstaten @qinweigong @Sarkar 
Making it possible for developers to understand whether Branch has a developer identity set for this User.
Previously, it wasn't possible for developers to know if Branch already had a developer identity set for a User, which persists through installs.