### PR TITLE
Update Update State

### DIFF
--- a/Branch-SDK/Branch-SDK/BNCSystemObserver.m
+++ b/Branch-SDK/Branch-SDK/BNCSystemObserver.m
@@ -141,10 +141,10 @@
     
     // No stored version
     if (!storedAppVersion) {
-        // Modification and Creation date are more than 60 seconds different indicates an update
-        // This would be the case that they were installing a new version of the app that was
+        // Modification and Creation date are more than one day's worth of seconds different indicates
+        // an update. This would be the case that they were installing a new version of the app that was
         // adding Branch for the first time, where we don't already have an NSUserDefaults value.
-        if (ABS([modificationDate timeIntervalSinceDate:creationDate]) > 60) {
+        if (ABS([modificationDate timeIntervalSinceDate:creationDate]) > 86400) {
             return @2;
         }
         

--- a/Branch-SDK/Branch-SDK/BNCSystemObserver.m
+++ b/Branch-SDK/Branch-SDK/BNCSystemObserver.m
@@ -141,7 +141,7 @@
     
     // No stored version
     if (!storedAppVersion) {
-        // Modification and Creation date are more than one day's worth of seconds different indicates
+        // Modification and Creation date are more than 24 hours' worth of seconds different indicates
         // an update. This would be the case that they were installing a new version of the app that was
         // adding Branch for the first time, where we don't already have an NSUserDefaults value.
         if (ABS([modificationDate timeIntervalSinceDate:creationDate]) > 86400) {

--- a/Branch-TestBed/Branch-SDK Functionality Tests/BNCSystemObserverTests.m
+++ b/Branch-TestBed/Branch-SDK Functionality Tests/BNCSystemObserverTests.m
@@ -33,8 +33,8 @@
 
 - (void)testGetUpdateStateWithNoStoredVersionAndDatesUnder60SecondsApart {
     NSDate *now = [NSDate date];
-    NSDate *lessThan60SecondsFromNow = [now dateByAddingTimeInterval:59];
-    [self stubCreationDate:now modificationDate:lessThan60SecondsFromNow];
+    NSDate *lessThan24HoursFromNow = [now dateByAddingTimeInterval:59];
+    [self stubCreationDate:now modificationDate:lessThan24HoursFromNow];
     [self stubNilValuesForStoredAndCurrentVersions];
     
     NSNumber *updateState = [BNCSystemObserver getUpdateState];
@@ -44,8 +44,8 @@
 
 - (void)testGetUpdateStateWithNoStoredVersionAndDatesMoreThan60SecondsApart {
     NSDate *now = [NSDate date];
-    NSDate *moreThan60SecondsFromNow = [now dateByAddingTimeInterval:61];
-    [self stubCreationDate:now modificationDate:moreThan60SecondsFromNow];
+    NSDate *moreThan24HoursFromNow = [now dateByAddingTimeInterval:86401];
+    [self stubCreationDate:now modificationDate:moreThan24HoursFromNow];
     [self stubNilValuesForStoredAndCurrentVersions];
     
     NSNumber *updateState = [BNCSystemObserver getUpdateState];


### PR DESCRIPTION
@derrickstaten 

Change update state check to one day to account for "long downloads" which may cause the doc dir and bundle to have > 1 min difference in timestamp.