### PR TITLE
Dont add source in encoding

### DIFF
--- a/Branch-SDK/Branch-SDK/BNCEncodingUtils.h
+++ b/Branch-SDK/Branch-SDK/BNCEncodingUtils.h
@@ -18,7 +18,6 @@
 
 + (NSString *)encodeArrayToJsonString:(NSArray *)dictionary;
 + (NSString *)encodeDictionaryToJsonString:(NSDictionary *)dictionary;
-+ (NSString *)encodeDictionaryToJsonString:(NSDictionary *)dictionary needSource:(BOOL)source;
 + (NSData *)encodeDictionaryToJsonData:(NSDictionary *)dictionary;
 
 + (NSDictionary *)decodeJsonDataToDictionary:(NSData *)jsonData;

--- a/Branch-SDK/Branch-SDK/BNCEncodingUtils.m
+++ b/Branch-SDK/Branch-SDK/BNCEncodingUtils.m
@@ -219,10 +219,6 @@ static const short _base64DecodingTable[256] = {
 }
 
 + (NSString *)encodeDictionaryToJsonString:(NSDictionary *)dictionary {
-    return [BNCEncodingUtils encodeDictionaryToJsonString:dictionary needSource:YES];
-}
-
-+ (NSString *)encodeDictionaryToJsonString:(NSDictionary *)dictionary needSource:(BOOL)source {
     NSMutableString *encodedDictionary = [[NSMutableString alloc] initWithString:@"{"];
     for (NSString *key in dictionary) {
         NSString *value = nil;
@@ -243,7 +239,7 @@ static const short _base64DecodingTable[256] = {
             string = NO;
         }
         else if ([obj isKindOfClass:[NSDictionary class]]) {
-            value = [BNCEncodingUtils encodeDictionaryToJsonString:obj needSource:NO]; // Sub dictionaries have no need for source
+            value = [BNCEncodingUtils encodeDictionaryToJsonString:obj];
             string = NO;
         }
         else if ([obj isKindOfClass:[NSNumber class]]) {
@@ -272,17 +268,11 @@ static const short _base64DecodingTable[256] = {
         }
     }
     
-    if (source) {
-        [encodedDictionary appendString:@"\"source\":\"ios\"}"];
+    if (encodedDictionary.length > 1) {
+        [encodedDictionary deleteCharactersInRange:NSMakeRange([encodedDictionary length] - 1, 1)];
     }
-    else {
-        // Delete the trailing comma. Not necessary for an empty dictionary
-        if (encodedDictionary.length > 1) {
-            [encodedDictionary deleteCharactersInRange:NSMakeRange([encodedDictionary length] - 1, 1)];
-        }
 
-        [encodedDictionary appendString:@"}"];
-    }
+    [encodedDictionary appendString:@"}"];
     
     if ([BNCPreferenceHelper isDebug]) {
         NSLog(@"encoded dictionary : %@", encodedDictionary);
@@ -316,7 +306,7 @@ static const short _base64DecodingTable[256] = {
             string = NO;
         }
         else if ([obj isKindOfClass:[NSDictionary class]]) {
-            value = [BNCEncodingUtils encodeDictionaryToJsonString:obj needSource:NO]; // Sub dictionaries have no need for source
+            value = [BNCEncodingUtils encodeDictionaryToJsonString:obj];
             string = NO;
         }
         else if ([obj isKindOfClass:[NSNumber class]]) {

--- a/Branch-SDK/Branch-SDK/BNCLinkData.m
+++ b/Branch-SDK/Branch-SDK/BNCLinkData.m
@@ -25,6 +25,7 @@ NSString * const BNC_LINK_DATA_IGNORE_UA_STRING = @"ignore_ua_string";
     self = [super init];
     if (self) {
         self.data = [[NSMutableDictionary alloc] init];
+        self.data[@"source"] = @"ios";
     }
     return self;
 }

--- a/Branch-SDK/Branch-SDK/BNCServerInterface.m
+++ b/Branch-SDK/Branch-SDK/BNCServerInterface.m
@@ -168,7 +168,6 @@
 - (NSDictionary *)prepareParamDict:(NSDictionary *)params key:(NSString *)key retryNumber:(NSInteger)retryNumber {
     NSMutableDictionary *fullParamDict = [[NSMutableDictionary alloc] init];
     [fullParamDict addEntriesFromDictionary:params];
-    fullParamDict[@"source"] = @"ios";
     fullParamDict[@"sdk"] = [NSString stringWithFormat:@"ios%@", SDK_VERSION];
     fullParamDict[@"retryNumber"] = @(retryNumber);
     

--- a/Branch-SDK/Branch-SDK/BNCServerInterface.m
+++ b/Branch-SDK/Branch-SDK/BNCServerInterface.m
@@ -168,6 +168,7 @@
 - (NSDictionary *)prepareParamDict:(NSDictionary *)params key:(NSString *)key retryNumber:(NSInteger)retryNumber {
     NSMutableDictionary *fullParamDict = [[NSMutableDictionary alloc] init];
     [fullParamDict addEntriesFromDictionary:params];
+    fullParamDict[@"source"] = @"ios";
     fullParamDict[@"sdk"] = [NSString stringWithFormat:@"ios%@", SDK_VERSION];
     fullParamDict[@"retryNumber"] = @(retryNumber);
     

--- a/Branch-SDK/Branch-SDK/Branch.m
+++ b/Branch-SDK/Branch-SDK/Branch.m
@@ -1185,7 +1185,7 @@ static int BNCDebugTriggerFingersSimulator = 2;
     
     NSData *jsonData = [BNCEncodingUtils encodeDictionaryToJsonData:params];
     NSString *base64EncodedParams = [BNCEncodingUtils base64EncodeData:jsonData];
-    [longUrl appendFormat:@"data=%@", base64EncodedParams];
+    [longUrl appendFormat:@"source=ios&data=%@", base64EncodedParams];
     
     return longUrl;
 }
@@ -1204,13 +1204,7 @@ static int BNCDebugTriggerFingersSimulator = 2;
     [post setupAlias:alias];
     [post setupMatchDuration:duration];
     [post setupIgnoreUAString:ignoreUAString];
-    
-    NSString *args = @"{\"source\":\"ios\"}";
-    if (params) {
-        args = [BNCEncodingUtils encodeDictionaryToJsonString:params];
-    }
-    
-    [post setupParams:args];
+    [post setupParams:[BNCEncodingUtils encodeDictionaryToJsonString:params]];
     return post;
 }
 

--- a/Branch-TestBed/Branch-SDK Functionality Tests/BNCEncodingUtilsTests.m
+++ b/Branch-TestBed/Branch-SDK Functionality Tests/BNCEncodingUtilsTests.m
@@ -52,6 +52,15 @@
     XCTAssertEqualObjects(expectedEncodedString, encodedValue);
 }
 
+- (void)testEncodingNilDictionaryToJsonString {
+    NSDictionary *dataDict = nil;
+    NSString *expectedEncodedString = @"{}";
+    
+    NSString *encodedValue = [BNCEncodingUtils encodeDictionaryToJsonString:dataDict];
+    
+    XCTAssertEqualObjects(expectedEncodedString, encodedValue);
+}
+
 - (void)testEncodeDictionaryToJsonStringWithNoKeys {
     NSDictionary *emptyDict = @{ };
     NSString *expectedEncodedString = @"{}";
@@ -119,6 +128,15 @@
 
 - (void)testEncodeArrayToJsonStringWithNoValues {
     NSArray *emptyArray = @[ ];
+    NSString *expectedEncodedString = @"[]";
+    
+    NSString *encodedValue = [BNCEncodingUtils encodeArrayToJsonString:emptyArray];
+    
+    XCTAssertEqualObjects(expectedEncodedString, encodedValue);
+}
+
+- (void)testEncodingEmptyArrayToJsonString {
+    NSArray *emptyArray = nil;
     NSString *expectedEncodedString = @"[]";
     
     NSString *encodedValue = [BNCEncodingUtils encodeArrayToJsonString:emptyArray];

--- a/Branch-TestBed/Branch-SDK Functionality Tests/BNCEncodingUtilsTests.m
+++ b/Branch-TestBed/Branch-SDK Functionality Tests/BNCEncodingUtilsTests.m
@@ -28,7 +28,7 @@
     NSDictionary *dataDict = @{ @"foo": @"bar", @"num": @1, @"array": @[ @"array", @"items" ], @"dict": @{ @"sub": @1 }, @"url": someUrl, @"date": date };
     NSString *expectedEncodedString = [NSString stringWithFormat:@"{\"foo\":\"bar\",\"num\":1,\"array\":[\"array\",\"items\"],\"dict\":{\"sub\":1},\"url\":\"https://branch.io\",\"date\":\"%@\"}", formattedDateString];
     
-    NSString *encodedValue = [BNCEncodingUtils encodeDictionaryToJsonString:dataDict needSource:NO];
+    NSString *encodedValue = [BNCEncodingUtils encodeDictionaryToJsonString:dataDict];
     
     XCTAssertEqualObjects(expectedEncodedString, encodedValue);
 }
@@ -38,7 +38,7 @@
     NSDictionary *dataDict = @{ @"foo": @"bar", @"random": arbitraryObj };
     NSString *expectedEncodedString = @"{\"foo\":\"bar\"}";
     
-    NSString *encodedValue = [BNCEncodingUtils encodeDictionaryToJsonString:dataDict needSource:NO];
+    NSString *encodedValue = [BNCEncodingUtils encodeDictionaryToJsonString:dataDict];
     
     XCTAssertEqualObjects(expectedEncodedString, encodedValue);
 }
@@ -47,7 +47,7 @@
     NSDictionary *dataDict = @{ @"foo": [NSNull null] };
     NSString *expectedEncodedString = @"{\"foo\":null}";
     
-    NSString *encodedValue = [BNCEncodingUtils encodeDictionaryToJsonString:dataDict needSource:NO];
+    NSString *encodedValue = [BNCEncodingUtils encodeDictionaryToJsonString:dataDict];
     
     XCTAssertEqualObjects(expectedEncodedString, encodedValue);
 }
@@ -56,32 +56,14 @@
     NSDictionary *emptyDict = @{ };
     NSString *expectedEncodedString = @"{}";
     
-    NSString *encodedValue = [BNCEncodingUtils encodeDictionaryToJsonString:emptyDict needSource:NO];
-    
-    XCTAssertEqualObjects(expectedEncodedString, encodedValue);
-}
-
-- (void)testEncodeDictionaryToJsonStringWithNoKeysAndSource {
-    NSDictionary *emptyDict = @{ };
-    NSString *expectedEncodedString = @"{\"source\":\"ios\"}";
-    
-    NSString *encodedValue = [BNCEncodingUtils encodeDictionaryToJsonString:emptyDict needSource:YES];
-    
-    XCTAssertEqualObjects(expectedEncodedString, encodedValue);
-}
-
-- (void)testEncodeDictionaryToJsonStringWithSubDictWithNeedSource {
-    NSDictionary *dataDict = @{ @"root": @{ @"sub": @1 } };
-    NSString *expectedEncodedString = @"{\"root\":{\"sub\":1},\"source\":\"ios\"}";
-    
-    NSString *encodedValue = [BNCEncodingUtils encodeDictionaryToJsonString:dataDict needSource:YES];
+    NSString *encodedValue = [BNCEncodingUtils encodeDictionaryToJsonString:emptyDict];
     
     XCTAssertEqualObjects(expectedEncodedString, encodedValue);
 }
 
 - (void)testSimpleEncodeDictionaryToJsonData {
     NSDictionary *dataDict = @{ @"foo": @"bar" };
-    NSData *expectedEncodedData = [@"{\"foo\":\"bar\",\"source\":\"ios\"}" dataUsingEncoding:NSUTF8StringEncoding];
+    NSData *expectedEncodedData = [@"{\"foo\":\"bar\"}" dataUsingEncoding:NSUTF8StringEncoding];
     
     NSData *encodedValue = [BNCEncodingUtils encodeDictionaryToJsonData:dataDict];
     

--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ This is the repository of our open source iOS SDK. There's a full demo app embed
 
 Check it out!
 
+## Important migration to v0.7.8
+The `source:iOS` attribute has been removed from the params dictionary for links.
+
 ## Important migration to v0.6.0
 
 We have deprecated the bnc_app_key and replaced that with the new branch_key. Please see [add branch key](#add-your-branch-key-to-your-project) for details.


### PR DESCRIPTION
@aaustin @derrickstaten @qinweigong @Sarkar 

Source shouldn't be added to every dictionary that is encoded, it should only be added where desired. Specifically, it should be added to url generation, where the creation source is present.