### PR TITLE
Double encoded params

### DIFF
--- a/Branch-SDK/Branch-SDK/BNCLinkData.h
+++ b/Branch-SDK/Branch-SDK/BNCLinkData.h
@@ -24,7 +24,7 @@ typedef NS_ENUM(NSUInteger, BranchLinkType) {
 @property (nonatomic, strong) NSString *channel;
 @property (nonatomic, strong) NSString *feature;
 @property (nonatomic, strong) NSString *stage;
-@property (nonatomic, strong) NSString *params;
+@property (nonatomic, strong) NSDictionary *params;
 @property (nonatomic, assign) NSUInteger duration;
 @property (nonatomic, strong) NSString *ignoreUAString;
 
@@ -34,7 +34,7 @@ typedef NS_ENUM(NSUInteger, BranchLinkType) {
 - (void)setupChannel:(NSString *)channel;
 - (void)setupFeature:(NSString *)feature;
 - (void)setupStage:(NSString *)stage;
-- (void)setupParams:(NSString *)params;
+- (void)setupParams:(NSDictionary *)params;
 - (void)setupMatchDuration:(NSUInteger)duration;
 - (void)setupIgnoreUAString:(NSString *)ignoreUAString;
 

--- a/Branch-SDK/Branch-SDK/BNCLinkData.m
+++ b/Branch-SDK/Branch-SDK/BNCLinkData.m
@@ -102,7 +102,7 @@ NSString * const BNC_LINK_DATA_IGNORE_UA_STRING = @"ignore_ua_string";
     }
 }
 
-- (void)setupParams:(NSString *)params {
+- (void)setupParams:(NSDictionary *)params {
     _params = params;
     [self.data setObject:params forKey:BNC_LINK_DATA_DATA];
 }
@@ -124,12 +124,13 @@ NSString * const BNC_LINK_DATA_IGNORE_UA_STRING = @"ignore_ua_string";
     NSUInteger result = 1;
     NSUInteger prime = 19;
 
+    NSString *encodedParams = [BNCEncodingUtils encodeDictionaryToJsonString:self.params];
     result = prime * result + self.type;
     result = prime * result + [[BNCEncodingUtils md5Encode:[self.alias lowercaseString]] hash];
     result = prime * result + [[BNCEncodingUtils md5Encode:[self.channel lowercaseString]] hash];
     result = prime * result + [[BNCEncodingUtils md5Encode:[self.feature lowercaseString]] hash];
     result = prime * result + [[BNCEncodingUtils md5Encode:[self.stage lowercaseString]] hash];
-    result = prime * result + [[BNCEncodingUtils md5Encode:[self.params lowercaseString]] hash];
+    result = prime * result + [[BNCEncodingUtils md5Encode:[encodedParams lowercaseString]] hash];
     result = prime * result + self.duration;
     
     for (NSString *tag in self.tags) {
@@ -159,7 +160,8 @@ NSString * const BNC_LINK_DATA_IGNORE_UA_STRING = @"ignore_ua_string";
         [coder encodeObject:self.stage forKey:BNC_LINK_DATA_STAGE];
     }
     if (self.params) {
-        [coder encodeObject:self.params forKey:BNC_LINK_DATA_DATA];
+        NSString *encodedParams = [BNCEncodingUtils encodeDictionaryToJsonString:self.params];
+        [coder encodeObject:encodedParams forKey:BNC_LINK_DATA_DATA];
     }
     if (self.duration > 0) {
         [coder encodeObject:[NSNumber numberWithInteger:self.duration] forKey:BNC_LINK_DATA_DURATION];
@@ -174,8 +176,10 @@ NSString * const BNC_LINK_DATA_IGNORE_UA_STRING = @"ignore_ua_string";
         self.channel = [coder decodeObjectForKey:BNC_LINK_DATA_CHANNEL];
         self.feature = [coder decodeObjectForKey:BNC_LINK_DATA_FEATURE];
         self.stage = [coder decodeObjectForKey:BNC_LINK_DATA_STAGE];
-        self.params = [coder decodeObjectForKey:BNC_LINK_DATA_DATA];
         self.duration = [[coder decodeObjectForKey:BNC_LINK_DATA_DURATION] intValue];
+        
+        NSString *encodedParams = [coder decodeObjectForKey:BNC_LINK_DATA_DATA];
+        self.params = [BNCEncodingUtils decodeJsonStringToDictionary:encodedParams];
     }
     return self;
 }

--- a/Branch-SDK/Branch-SDK/BNCLinkData.m
+++ b/Branch-SDK/Branch-SDK/BNCLinkData.m
@@ -103,8 +103,10 @@ NSString * const BNC_LINK_DATA_IGNORE_UA_STRING = @"ignore_ua_string";
 }
 
 - (void)setupParams:(NSDictionary *)params {
-    _params = params;
-    [self.data setObject:params forKey:BNC_LINK_DATA_DATA];
+    if (params) {
+        _params = params;
+        [self.data setObject:params forKey:BNC_LINK_DATA_DATA];
+    }
 }
 
 

--- a/Branch-SDK/Branch-SDK/Branch.m
+++ b/Branch-SDK/Branch-SDK/Branch.m
@@ -863,7 +863,7 @@ static int BNCDebugTriggerFingersSimulator = 2;
     [post setupAlias:alias];
     [post setupMatchDuration:duration];
     [post setupIgnoreUAString:ignoreUAString];
-    [post setupParams:[BNCEncodingUtils encodeDictionaryToJsonString:params]];
+    [post setupParams:params];
 
     return post;
 }

--- a/Branch-SDK/Branch-SDK/BranchShortUrlRequest.m
+++ b/Branch-SDK/Branch-SDK/BranchShortUrlRequest.m
@@ -135,7 +135,7 @@
         [self.linkData setupStage:_stage];
         [self.linkData setupAlias:_alias];
         [self.linkData setupMatchDuration:_matchDuration];
-        [self.linkData setupParams:[BNCEncodingUtils encodeDictionaryToJsonString:_params]];
+        [self.linkData setupParams:_params];
     }
     
     return self;

--- a/Branch-TestBed/Branch-SDK Functionality Tests/BNCEncodingUtilsTests.m
+++ b/Branch-TestBed/Branch-SDK Functionality Tests/BNCEncodingUtilsTests.m
@@ -70,6 +70,15 @@
     XCTAssertEqualObjects(expectedEncodedString, encodedValue);
 }
 
+- (void)testEncodeDictionaryToJsonStringWithQuotes {
+    NSDictionary *dictionaryWithQuotes = @{ @"my\"cool\"key": @"my\"cool\"value" };
+    NSString *expectedEncodedString = @"{\"my\\\"cool\\\"key\":\"my\\\"cool\\\"value\"}";
+ 
+    NSString *encodedValue = [BNCEncodingUtils encodeDictionaryToJsonString:dictionaryWithQuotes];
+    
+    XCTAssertEqualObjects(expectedEncodedString, encodedValue);
+}
+
 - (void)testSimpleEncodeDictionaryToJsonData {
     NSDictionary *dataDict = @{ @"foo": @"bar" };
     NSData *expectedEncodedData = [@"{\"foo\":\"bar\"}" dataUsingEncoding:NSUTF8StringEncoding];
@@ -140,6 +149,15 @@
     NSString *expectedEncodedString = @"[]";
     
     NSString *encodedValue = [BNCEncodingUtils encodeArrayToJsonString:emptyArray];
+    
+    XCTAssertEqualObjects(expectedEncodedString, encodedValue);
+}
+
+- (void)testEncodeArrayToJsonStringWithQuotes {
+    NSArray *arrayWithQuotes = @[ @"my\"cool\"value1", @"my\"cool\"value2" ];
+    NSString *expectedEncodedString = @"[\"my\\\"cool\\\"value1\",\"my\\\"cool\\\"value2\"]";
+    
+    NSString *encodedValue = [BNCEncodingUtils encodeArrayToJsonString:arrayWithQuotes];
     
     XCTAssertEqualObjects(expectedEncodedString, encodedValue);
 }


### PR DESCRIPTION
@qinweigong 

Just keeping params a dictionary until it actually needs to be converted. This prevents the encoding from happening twice.