### PR TITLE
Dissociative Callbacks

### DIFF
--- a/Branch-SDK/Branch-SDK/BNCServerRequestQueue.h
+++ b/Branch-SDK/Branch-SDK/BNCServerRequestQueue.h
@@ -8,6 +8,8 @@
 
 #import "BNCServerRequest.h"
 
+@class BranchOpenRequest;
+
 @interface BNCServerRequestQueue : NSObject
 
 @property (nonatomic, readonly) unsigned int size;
@@ -25,7 +27,7 @@
 
 - (BOOL)containsInstallOrOpen;
 - (BOOL)containsClose;
-- (void)moveInstallOrOpenToFront:(NSInteger)networkCount;
+- (BranchOpenRequest *)moveInstallOrOpenToFront:(NSInteger)networkCount;
 
 + (id)getInstance;
 

--- a/Branch-SDK/Branch-SDK/BNCServerRequestQueue.m
+++ b/Branch-SDK/Branch-SDK/BNCServerRequestQueue.m
@@ -8,8 +8,8 @@
 
 #import "BNCServerRequestQueue.h"
 #import "BNCPreferenceHelper.h"
-#import "BranchOpenRequest.h"
 #import "BranchCloseRequest.h"
+#import "BranchOpenRequest.h"
 
 NSString * const STORAGE_KEY = @"BNCServerRequestQueue";
 NSUInteger const BATCH_WRITE_TIMEOUT = 3;
@@ -133,7 +133,7 @@ NSUInteger const BATCH_WRITE_TIMEOUT = 3;
     return NO;
 }
 
-- (void)moveInstallOrOpenToFront:(NSInteger)networkCount {
+- (BranchOpenRequest *)moveInstallOrOpenToFront:(NSInteger)networkCount {
     BOOL requestAlreadyInProgress = networkCount > 0;
 
     BNCServerRequest *openOrInstallRequest;
@@ -143,7 +143,7 @@ NSUInteger const BATCH_WRITE_TIMEOUT = 3;
             
             // Already in front, nothing to do
             if (i == 0 || (i == 1 && requestAlreadyInProgress)) {
-                return;
+                return (BranchOpenRequest *)req;
             }
 
             // Otherwise, pull this request out and stop early
@@ -154,7 +154,7 @@ NSUInteger const BATCH_WRITE_TIMEOUT = 3;
     
     if (!openOrInstallRequest) {
         NSLog(@"[Branch Warning] No install or open request in queue while trying to move it to the front");
-        return;
+        return nil;
     }
     
     if (!requestAlreadyInProgress || !self.queue.count) {
@@ -163,6 +163,8 @@ NSUInteger const BATCH_WRITE_TIMEOUT = 3;
     else {
         [self insert:openOrInstallRequest at:1];
     }
+    
+    return (BranchOpenRequest *)openOrInstallRequest;
 }
 
 - (BOOL)containsClose {

--- a/Branch-SDK/Branch-SDK/BNCServerRequestQueue.m
+++ b/Branch-SDK/Branch-SDK/BNCServerRequestQueue.m
@@ -143,7 +143,7 @@ NSUInteger const BATCH_WRITE_TIMEOUT = 3;
         }
     }
     
-    if (networkCount == 0) {
+    if (networkCount == 0 || !self.queue.count) {
         [self insert:openOrInstallRequest at:0];
     }
     else {

--- a/Branch-SDK/Branch-SDK/BNCServerRequestQueue.m
+++ b/Branch-SDK/Branch-SDK/BNCServerRequestQueue.m
@@ -134,16 +134,30 @@ NSUInteger const BATCH_WRITE_TIMEOUT = 3;
 }
 
 - (void)moveInstallOrOpenToFront:(NSInteger)networkCount {
+    BOOL requestAlreadyInProgress = networkCount > 0;
+
     BNCServerRequest *openOrInstallRequest;
     for (int i = 0; i < self.queue.count; i++) {
         BNCServerRequest *req = [self.queue objectAtIndex:i];
         if ([req isKindOfClass:[BranchOpenRequest class]]) {
+            
+            // Already in front, nothing to do
+            if (i == 0 || (i == 1 && requestAlreadyInProgress)) {
+                return;
+            }
+
+            // Otherwise, pull this request out and stop early
             openOrInstallRequest = [self removeAt:i];
             break;
         }
     }
     
-    if (networkCount == 0 || !self.queue.count) {
+    if (!openOrInstallRequest) {
+        NSLog(@"[Branch Warning] No install or open request in queue while trying to move it to the front");
+        return;
+    }
+    
+    if (!requestAlreadyInProgress || !self.queue.count) {
         [self insert:openOrInstallRequest at:0];
     }
     else {

--- a/Branch-SDK/Branch-SDK/Branch.m
+++ b/Branch-SDK/Branch-SDK/Branch.m
@@ -1071,9 +1071,7 @@ static int BNCDebugTriggerFingersSimulator = 2;
     // Make sure a callback is associated with this request. This callback can
     // be cleared if the app is terminated while an Open/Install is pending.
     else {
-        [self.requestQueue moveInstallOrOpenToFront:self.networkCount];
-        
-        BranchOpenRequest *req = (BranchOpenRequest *)[self.requestQueue peek];
+        BranchOpenRequest *req = [self.requestQueue moveInstallOrOpenToFront:self.networkCount];
         req.callback = initSessionCallback;
     }
     

--- a/Branch-SDK/Branch-SDK/Branch.m
+++ b/Branch-SDK/Branch-SDK/Branch.m
@@ -1024,10 +1024,7 @@ static int BNCDebugTriggerFingersSimulator = 2;
     
     // If the session is not yet initialized
     if (!self.isInitialized) {
-        // If the open/install request hasn't been added, do so.
-        if (![self.requestQueue containsInstallOrOpen]) {
-            [self initializeSession];
-        }
+        [self initializeSession];
     }
     // If the session was initialized, but callCallback was specified, do so.
     else if (callCallback) {

--- a/Branch-SDK/Branch-SDK/BranchOpenRequest.h
+++ b/Branch-SDK/Branch-SDK/BranchOpenRequest.h
@@ -11,6 +11,8 @@
 
 @interface BranchOpenRequest : BNCServerRequest
 
+@property (strong, nonatomic) callbackWithStatus callback;
+
 - (id)initWithCallback:(callbackWithStatus)callback;
 - (id)initWithCallback:(callbackWithStatus)callback allowInstallParamsToBeCleared:(BOOL)allowInstallParamsToBeCleared;
 

--- a/Branch-SDK/Branch-SDK/BranchOpenRequest.m
+++ b/Branch-SDK/Branch-SDK/BranchOpenRequest.m
@@ -12,7 +12,6 @@
 
 @interface BranchOpenRequest ()
 
-@property (strong, nonatomic) callbackWithStatus callback;
 @property (assign, nonatomic) BOOL allowInstallParamsToBeCleared;
 
 @end

--- a/Branch-TestBed/Branch-SDK Functionality Tests/BNCServerRequestQueueTests.m
+++ b/Branch-TestBed/Branch-SDK Functionality Tests/BNCServerRequestQueueTests.m
@@ -1,0 +1,116 @@
+//
+//  BNCServerRequestQueueTests.m
+//  Branch-TestBed
+//
+//  Created by Graham Mueller on 6/17/15.
+//  Copyright (c) 2015 Branch Metrics. All rights reserved.
+//
+
+#import "BranchTest.h"
+#import "BNCServerRequestQueue.h"
+#import "BranchOpenRequest.h"
+#import <OCMock/OCMock.h>
+
+@interface BNCServerRequestQueueTests : BranchTest
+
+@end
+
+@implementation BNCServerRequestQueueTests
+
+#pragma mark - MoveOpenOrInstallToFront tests
+- (void)testMoveOpenOrInstallToFrontWhenEmpty {
+    BNCServerRequestQueue *requestQueue = [[BNCServerRequestQueue alloc] init];
+    
+    XCTAssertNoThrow([requestQueue moveInstallOrOpenToFront:0]);
+}
+
+- (void)testMoveOpenOrInstallToFrontWhenNotPresent {
+    BNCServerRequestQueue *requestQueue = [[BNCServerRequestQueue alloc] init];
+    [requestQueue insert:[[BNCServerRequest alloc] init] at:0];
+    [requestQueue insert:[[BNCServerRequest alloc] init] at:0];
+    
+    XCTAssertNoThrow([requestQueue moveInstallOrOpenToFront:0]);
+}
+
+- (void)testMoveOpenOrInstallToFrontWhenAlreadyInFrontAndNoRequestsInProgress {
+    BNCServerRequestQueue *requestQueue = [[BNCServerRequestQueue alloc] init];
+    [requestQueue insert:[[BranchOpenRequest alloc] init] at:0];
+    
+    id requestQueueMock = OCMPartialMock(requestQueue);
+    [[requestQueueMock reject] removeAt:0];
+    
+    [requestQueue moveInstallOrOpenToFront:0];
+}
+
+- (void)testMoveOpenOrInstallToFrontWhenAlreadyInFrontWithRequestsInProgress {
+    BNCServerRequestQueue *requestQueue = [[BNCServerRequestQueue alloc] init];
+    [requestQueue insert:[[BranchOpenRequest alloc] init] at:0];
+
+    id requestQueueMock = OCMPartialMock(requestQueue);
+    [[requestQueueMock reject] removeAt:0];
+    
+    [requestQueue moveInstallOrOpenToFront:1];
+}
+
+- (void)testMoveOpenOrInstallToFrontWhenSecondInLineWithRequestsInProgress {
+    BNCServerRequestQueue *requestQueue = [[BNCServerRequestQueue alloc] init];
+    [requestQueue insert:[[BNCServerRequest alloc] init] at:0];
+    [requestQueue insert:[[BranchOpenRequest alloc] init] at:1];
+    
+    id requestQueueMock = OCMPartialMock(requestQueue);
+    [[requestQueueMock reject] removeAt:1];
+    
+    [requestQueue moveInstallOrOpenToFront:1];
+}
+
+- (void)testMoveOpenOrInstallToFrontWhenSecondInLineWithNoRequestsInProgress {
+    BNCServerRequestQueue *requestQueue = [[BNCServerRequestQueue alloc] init];
+    BranchOpenRequest *openRequest = [[BranchOpenRequest alloc] init];
+    [requestQueue insert:[[BNCServerRequest alloc] init] at:0];
+    [requestQueue insert:openRequest at:1];
+    
+    id requestQueueMock = OCMPartialMock(requestQueue);
+    [[[requestQueueMock expect] andForwardToRealObject] removeAt:1];
+    
+    [requestQueue moveInstallOrOpenToFront:0];
+    
+    XCTAssertEqual([requestQueue peek], openRequest);
+    
+    [requestQueueMock verify];
+}
+
+- (void)testMoveOpenOrInstallToFrontWhenThirdInLineWithRequestsInProgress {
+    BNCServerRequestQueue *requestQueue = [[BNCServerRequestQueue alloc] init];
+    BranchOpenRequest *openRequest = [[BranchOpenRequest alloc] init];
+    [requestQueue insert:[[BNCServerRequest alloc] init] at:0];
+    [requestQueue insert:[[BNCServerRequest alloc] init] at:1];
+    [requestQueue insert:openRequest at:2];
+    
+    id requestQueueMock = OCMPartialMock(requestQueue);
+    [[[requestQueueMock expect] andForwardToRealObject] removeAt:2];
+    
+    [requestQueue moveInstallOrOpenToFront:1];
+    
+    XCTAssertEqual([requestQueue peekAt:1], openRequest);
+    
+    [requestQueueMock verify];
+}
+
+- (void)testMoveOpenOrInstallToFrontWhenThirdInLineWithNoRequestsInProgress {
+    BNCServerRequestQueue *requestQueue = [[BNCServerRequestQueue alloc] init];
+    BranchOpenRequest *openRequest = [[BranchOpenRequest alloc] init];
+    [requestQueue insert:[[BNCServerRequest alloc] init] at:0];
+    [requestQueue insert:[[BNCServerRequest alloc] init] at:1];
+    [requestQueue insert:openRequest at:2];
+    
+    id requestQueueMock = OCMPartialMock(requestQueue);
+    [[[requestQueueMock expect] andForwardToRealObject] removeAt:2];
+    
+    [requestQueue moveInstallOrOpenToFront:0];
+    
+    XCTAssertEqual([requestQueue peek], openRequest);
+    
+    [requestQueueMock verify];
+}
+
+@end

--- a/Branch-TestBed/Branch-SDK Functionality Tests/BranchNetworkScenarioTests.m
+++ b/Branch-TestBed/Branch-SDK Functionality Tests/BranchNetworkScenarioTests.m
@@ -316,6 +316,7 @@
             BranchOpenRequest *openRequest = (BranchOpenRequest *)request;
             openRequest.callback = nil;
             [[[queueMock stub] andReturn:request] peek];
+            [[[queueMock stub] andReturn:openRequest] moveInstallOrOpenToFront:0];
             return YES;
         }
         

--- a/Branch-TestBed/Branch-TestBed.xcodeproj/project.pbxproj
+++ b/Branch-TestBed/Branch-TestBed.xcodeproj/project.pbxproj
@@ -89,6 +89,7 @@
 		46946BA51B2689A100627BCC /* BranchConnectDebugRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 4642E6A51B1FA1DB006E4C1F /* BranchConnectDebugRequest.h */; };
 		46946BA61B2689A100627BCC /* BranchDisconnectDebugRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 4642E6A91B1FA2AA006E4C1F /* BranchDisconnectDebugRequest.h */; };
 		46946BA71B2689A100627BCC /* BranchLogRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 4642E6AD1B1FA303006E4C1F /* BranchLogRequest.h */; };
+		46A7A1761B320B280028747A /* BNCServerRequestQueueTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 46A7A1751B320B280028747A /* BNCServerRequestQueueTests.m */; };
 		46ABC9561B2F5D740049F989 /* BNCLinkDataTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 46ABC9551B2F5D740049F989 /* BNCLinkDataTests.m */; };
 		46D0B6FA1ACD8EF000CDDE82 /* BNCPreferenceHelperTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 46D0B6F91ACD8EF000CDDE82 /* BNCPreferenceHelperTests.m */; };
 		46DC406E1B2A328900D2D203 /* AdSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 67BBCF271A69E49A009C7DAE /* AdSupport.framework */; };
@@ -197,6 +198,7 @@
 		467309471AF2C4FB005B8848 /* BranchTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BranchTest.h; sourceTree = "<group>"; };
 		467309481AF2C4FB005B8848 /* BranchTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BranchTest.m; sourceTree = "<group>"; };
 		4683F0781B20A9ED00A432E7 /* BranchConnectDebugRequestTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BranchConnectDebugRequestTests.m; sourceTree = "<group>"; };
+		46A7A1751B320B280028747A /* BNCServerRequestQueueTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BNCServerRequestQueueTests.m; sourceTree = "<group>"; };
 		46ABC9551B2F5D740049F989 /* BNCLinkDataTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BNCLinkDataTests.m; sourceTree = "<group>"; };
 		46D0B6F91ACD8EF000CDDE82 /* BNCPreferenceHelperTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BNCPreferenceHelperTests.m; sourceTree = "<group>"; };
 		46FD92B91AE7E8F80012E78F /* BNCSystemObserverTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BNCSystemObserverTests.m; sourceTree = "<group>"; };
@@ -490,9 +492,10 @@
 				46D0B6F91ACD8EF000CDDE82 /* BNCPreferenceHelperTests.m */,
 				461019451AE551A500379A15 /* BranchNetworkScenarioTests.m */,
 				46FD92B91AE7E8F80012E78F /* BNCSystemObserverTests.m */,
-				7E6B3B531AA42D0E005F45BF /* Supporting Files */,
 				4683F0781B20A9ED00A432E7 /* BranchConnectDebugRequestTests.m */,
 				46ABC9551B2F5D740049F989 /* BNCLinkDataTests.m */,
+				7E6B3B531AA42D0E005F45BF /* Supporting Files */,
+				46A7A1751B320B280028747A /* BNCServerRequestQueueTests.m */,
 			);
 			path = "Branch-SDK Functionality Tests";
 			sourceTree = "<group>";
@@ -938,6 +941,7 @@
 			files = (
 				7E6B3B561AA42D0E005F45BF /* Branch_SDK_Functionality_Tests.m in Sources */,
 				461019461AE551A500379A15 /* BranchNetworkScenarioTests.m in Sources */,
+				46A7A1761B320B280028747A /* BNCServerRequestQueueTests.m in Sources */,
 				46ABC9561B2F5D740049F989 /* BNCLinkDataTests.m in Sources */,
 				46FD92BA1AE7E8F80012E78F /* BNCSystemObserverTests.m in Sources */,
 				464EA3981ACB1797000E4094 /* BNCServerInterfaceTests.m in Sources */,


### PR DESCRIPTION
@derrickstaten 

When an Open/Install request is persisted to disk, its callback is lost.
This means that even when it is actually executed, the Branch file is never informed of the update, and never marks itself as initialized.
Now, we always re-add the callback to make sure that link is still in place.