### PR TITLE
Non singleton preference helper

### DIFF
--- a/Branch-SDK/Branch-SDK/BNCEncodingUtils.m
+++ b/Branch-SDK/Branch-SDK/BNCEncodingUtils.m
@@ -257,7 +257,7 @@ static const short _base64DecodingTable[256] = {
 
     [encodedDictionary appendString:@"}"];
     
-    if ([BNCPreferenceHelper isDebug]) {
+    if ([[BNCPreferenceHelper preferenceHelper] isDebug]) {
         NSLog(@"encoded dictionary : %@", encodedDictionary);
     }
     
@@ -320,7 +320,7 @@ static const short _base64DecodingTable[256] = {
     [encodedArray deleteCharactersInRange:NSMakeRange([encodedArray length] - 1, 1)];
     [encodedArray appendString:@"]"];
     
-    if ([BNCPreferenceHelper isDebug]) {
+    if ([[BNCPreferenceHelper preferenceHelper] isDebug]) {
         NSLog(@"encoded array : %@", encodedArray);
     }
 

--- a/Branch-SDK/Branch-SDK/BNCPreferenceHelper.h
+++ b/Branch-SDK/Branch-SDK/BNCPreferenceHelper.h
@@ -13,86 +13,46 @@
 
 @interface BNCPreferenceHelper : NSObject
 
+@property (strong, nonatomic) NSString *branchKey;
+@property (strong, nonatomic) NSString *appKey;
+@property (strong, nonatomic) NSString *lastRunBranchKey;
+@property (strong, nonatomic) NSString *appVersion;
+@property (strong, nonatomic) NSString *deviceFingerprintID;
+@property (strong, nonatomic) NSString *sessionID;
+@property (strong, nonatomic) NSString *identityID;
+@property (strong, nonatomic) NSString *linkClickIdentifier;
+@property (strong, nonatomic) NSString *userUrl;
+@property (strong, nonatomic) NSString *userIdentity;
+@property (strong, nonatomic) NSString *sessionParams;
+@property (strong, nonatomic) NSString *installParams;
+@property (assign, nonatomic) BOOL isReferrable;
+@property (assign, nonatomic) BOOL isDebug;
+@property (assign, nonatomic) BOOL isConnectedToRemoteDebug;
 @property (assign, nonatomic) NSInteger retryCount;
 @property (assign, nonatomic) NSInteger retryInterval;
 @property (assign, nonatomic) NSInteger timeout;
 
-+ (NSString *)getAPIBaseURL;
-+ (NSString *)getAPIURL:(NSString *) endpoint;
++ (BNCPreferenceHelper *)preferenceHelper;
 
-+ (void)setTimeout:(NSInteger)timeout;
-+ (NSInteger)getTimeout;
+- (NSString *)getAPIBaseURL;
+- (NSString *)getAPIURL:(NSString *)endpoint;
+- (NSString *)getBranchKey:(BOOL)isLive;
 
-+ (void)setRetryInterval:(NSInteger)retryInterval;
-+ (NSInteger)getRetryInterval;
+- (void)setAppListCheckDone;
+- (BOOL)getNeedAppListCheck;
 
-+ (void)setRetryCount:(NSInteger)retryCount;
-+ (NSInteger)getRetryCount;
+- (void)clearUserCreditsAndCounts;
 
-+ (NSString *)getAppKey;
-+ (void)setAppKey:(NSString *)appKey;
+- (void)setCreditCount:(NSInteger)count;
+- (void)setCreditCount:(NSInteger)count forBucket:(NSString *)bucket;
+- (NSInteger)getCreditCount;
+- (NSInteger)getCreditCountForBucket:(NSString *)bucket;
 
-+ (NSString *)getBranchKey:(BOOL)isLive;
-+ (void)setBranchKey:(NSString *)branchKey;
+- (void)setActionTotalCount:(NSString *)action withCount:(NSInteger)count;
+- (void)setActionUniqueCount:(NSString *)action withCount:(NSInteger)count;
+- (NSInteger)getActionTotalCount:(NSString *)action;
+- (NSInteger)getActionUniqueCount:(NSString *)action;
 
-+ (NSString *)getLastRunBranchKey;
-+ (void)setLastRunBranchKey:(NSString *)lastRunBranchKey;
-
-+ (NSString *)getAppVersion;
-+ (void)setAppVersion:(NSString *)appVersion;
-
-+ (void)setDeviceFingerprintID:(NSString *)deviceID;
-+ (NSString *)getDeviceFingerprintID;
-
-+ (void)setSessionID:(NSString *)sessionID;
-+ (NSString *)getSessionID;
-
-+ (void)setIdentityID:(NSString *)identityID;
-+ (NSString *)getIdentityID;
-
-+ (void)setLinkClickIdentifier:(NSString *)linkClickIdentifier;
-+ (NSString *)getLinkClickIdentifier;
-
-+ (void)setLinkClickID:(NSString *)linkClickId;
-+ (NSString *)getLinkClickID;
-
-+ (void)setSessionParams:(NSString *)sessionParams;
-+ (NSString *)getSessionParams;
-
-+ (void)setInstallParams:(NSString *)installParams;
-+ (NSString *)getInstallParams;
-
-+ (void)setUserURL:(NSString *)userUrl;
-+ (NSString *)getUserURL;
-
-+ (void)setUserIdentity:(NSString *)userIdentity;
-+ (NSString *)getUserIdentity;
-
-+ (void)setAppListCheckDone;
-+ (BOOL)getNeedAppListCheck;
-
-+ (BOOL)getIsReferrable;
-+ (void)setIsReferrable;
-+ (void)clearIsReferrable;
-
-+ (void)clearUserCreditsAndCounts;
-
-+ (void)setCreditCount:(NSInteger)count;
-+ (void)setCreditCount:(NSInteger)count forBucket:(NSString *)bucket;
-+ (NSInteger)getCreditCount;
-+ (NSInteger)getCreditCountForBucket:(NSString *)bucket;
-
-+ (void)setActionTotalCount:(NSString *)action withCount:(NSInteger)count;
-+ (void)setActionUniqueCount:(NSString *)action withCount:(NSInteger)count;
-+ (NSInteger)getActionTotalCount:(NSString *)action;
-+ (NSInteger)getActionUniqueCount:(NSString *)action;
-
-+ (BOOL)isDebug;
-+ (void)setDebug:(BOOL)debug;
-+ (void)clearDebug;
-+ (BOOL)isConnectedToRemoteDebug;
-+ (void)setConnectedToRemoteDebug:(BOOL)connectedToRemoteDebug;
-
-+ (void)log:(NSString *)filename line:(int)line message:(NSString *)format, ...;
+- (void)log:(NSString *)filename line:(int)line message:(NSString *)format, ...;
 
 @end

--- a/Branch-SDK/Branch-SDK/BNCPreferenceHelper.m
+++ b/Branch-SDK/Branch-SDK/BNCPreferenceHelper.m
@@ -15,6 +15,8 @@ static const NSInteger DEFAULT_RETRY_INTERVAL = 0;
 static const NSInteger DEFAULT_RETRY_COUNT = 1;
 static const NSInteger APP_READ_INTERVAL = 520000;
 
+NSString * const BRANCH_PREFS_FILE = @"BNCPreferences";
+
 NSString * const BRANCH_PREFS_KEY_APP_KEY = @"bnc_app_key";
 NSString * const BRANCH_PREFS_KEY_APP_VERSION = @"bnc_app_version";
 NSString * const BRANCH_PREFS_KEY_LAST_RUN_BRANCH_KEY = @"bnc_last_run_branch_key";
@@ -40,6 +42,7 @@ NSString * const BRANCH_PREFS_KEY_UNIQUE_BASE = @"bnc_unique_base_";
 
 @interface BNCPreferenceHelper ()
 
+@property (strong, nonatomic) NSMutableDictionary *persistenceDict;
 @property (strong, nonatomic) NSMutableDictionary *countsDictionary;
 @property (strong, nonatomic) NSMutableDictionary *creditsDictionary;
 @property (assign, nonatomic) BOOL isUsingLiveKey;
@@ -67,7 +70,7 @@ NSString * const BRANCH_PREFS_KEY_UNIQUE_BASE = @"bnc_unique_base_";
         
         _isDebug = NO;
         _isConnectedToRemoteDebug = NO;
-        _isReferrable = [BNCPreferenceHelper readBoolFromDefaults:KEY_IS_REFERRABLE];
+        _isReferrable = [self readBoolFromDefaults:BRANCH_PREFS_KEY_IS_REFERRABLE];
     }
     
     return self;
@@ -113,7 +116,7 @@ NSString * const BRANCH_PREFS_KEY_UNIQUE_BASE = @"bnc_unique_base_";
 
 - (NSString *)getAppKey {
     if (!_appKey) {
-        _appKey = [[[NSBundle mainBundle] infoDictionary] objectForKey:KEY_APP_KEY];
+        _appKey = [[[NSBundle mainBundle] infoDictionary] objectForKey:BRANCH_PREFS_KEY_APP_KEY];
     }
     
     return _appKey;
@@ -124,7 +127,7 @@ NSString * const BRANCH_PREFS_KEY_UNIQUE_BASE = @"bnc_unique_base_";
     
     if (![_appKey isEqualToString:appKey]) {
         _appKey = appKey;
-        [BNCPreferenceHelper writeObjectToDefaults:KEY_APP_KEY value:appKey];
+        [self writeObjectToDefaults:BRANCH_PREFS_KEY_APP_KEY value:appKey];
     }
 }
 
@@ -155,7 +158,7 @@ NSString * const BRANCH_PREFS_KEY_UNIQUE_BASE = @"bnc_unique_base_";
 
 - (NSString *)getLastRunBranchKey {
     if (!_lastRunBranchKey) {
-        _lastRunBranchKey = [BNCPreferenceHelper readStringFromDefaults:KEY_LAST_RUN_BRANCH_KEY];
+        _lastRunBranchKey = [self readStringFromDefaults:BRANCH_PREFS_KEY_LAST_RUN_BRANCH_KEY];
     }
     
     return _lastRunBranchKey;
@@ -164,13 +167,13 @@ NSString * const BRANCH_PREFS_KEY_UNIQUE_BASE = @"bnc_unique_base_";
 - (void)setLastRunBranchKey:(NSString *)lastRunBranchKey {
     if (![_lastRunBranchKey isEqualToString:lastRunBranchKey]) {
         _lastRunBranchKey = lastRunBranchKey;
-        [BNCPreferenceHelper writeObjectToDefaults:KEY_LAST_RUN_BRANCH_KEY value:lastRunBranchKey];
+        [self writeObjectToDefaults:BRANCH_PREFS_KEY_LAST_RUN_BRANCH_KEY value:lastRunBranchKey];
     }
 }
 
 - (NSString *)getAppVersion {
     if (!_appVersion) {
-        _appVersion = [BNCPreferenceHelper readStringFromDefaults:KEY_APP_VERSION];
+        _appVersion = [self readStringFromDefaults:BRANCH_PREFS_KEY_APP_VERSION];
     }
     
     return _appVersion;
@@ -179,13 +182,13 @@ NSString * const BRANCH_PREFS_KEY_UNIQUE_BASE = @"bnc_unique_base_";
 - (void)setAppVersion:(NSString *)appVersion {
     if (![_appVersion isEqualToString:appVersion]) {
         _appVersion = appVersion;
-        [BNCPreferenceHelper writeObjectToDefaults:KEY_APP_VERSION value:appVersion];
+        [self writeObjectToDefaults:BRANCH_PREFS_KEY_APP_VERSION value:appVersion];
     }
 }
 
 - (NSString *)getDeviceFingerprintID {
     if (!_deviceFingerprintID) {
-        _deviceFingerprintID = [BNCPreferenceHelper readStringFromDefaults:KEY_DEVICE_FINGERPRINT_ID];
+        _deviceFingerprintID = [self readStringFromDefaults:BRANCH_PREFS_KEY_DEVICE_FINGERPRINT_ID];
     }
     
     return _deviceFingerprintID;
@@ -194,13 +197,13 @@ NSString * const BRANCH_PREFS_KEY_UNIQUE_BASE = @"bnc_unique_base_";
 - (void)setDeviceFingerprintID:(NSString *)deviceFingerprintID {
     if (![_deviceFingerprintID isEqualToString:deviceFingerprintID]) {
         _deviceFingerprintID = deviceFingerprintID;
-        [BNCPreferenceHelper writeObjectToDefaults:KEY_DEVICE_FINGERPRINT_ID value:deviceFingerprintID];
+        [self writeObjectToDefaults:BRANCH_PREFS_KEY_DEVICE_FINGERPRINT_ID value:deviceFingerprintID];
     }
 }
 
 - (NSString *)getSessionID {
     if (!_sessionID) {
-        _sessionID = [BNCPreferenceHelper readStringFromDefaults:KEY_SESSION_ID];
+        _sessionID = [self readStringFromDefaults:BRANCH_PREFS_KEY_SESSION_ID];
     }
     
     return _sessionID;
@@ -209,13 +212,13 @@ NSString * const BRANCH_PREFS_KEY_UNIQUE_BASE = @"bnc_unique_base_";
 - (void)setSessionID:(NSString *)sessionID {
     if (![_sessionID isEqualToString:sessionID]) {
         _sessionID = sessionID;
-        [BNCPreferenceHelper writeObjectToDefaults:KEY_SESSION_ID value:sessionID];
+        [self writeObjectToDefaults:BRANCH_PREFS_KEY_SESSION_ID value:sessionID];
     }
 }
 
 - (NSString *)getIdentityID {
     if (!_identityID) {
-        _identityID = [BNCPreferenceHelper readStringFromDefaults:KEY_IDENTITY_ID];
+        _identityID = [self readStringFromDefaults:BRANCH_PREFS_KEY_IDENTITY_ID];
     }
     
     return _identityID;
@@ -224,13 +227,13 @@ NSString * const BRANCH_PREFS_KEY_UNIQUE_BASE = @"bnc_unique_base_";
 - (void)setIdentityID:(NSString *)identityID {
     if (![_identityID isEqualToString:identityID]) {
         _identityID = identityID;
-        [BNCPreferenceHelper writeObjectToDefaults:KEY_IDENTITY_ID value:identityID];
+        [self writeObjectToDefaults:BRANCH_PREFS_KEY_IDENTITY_ID value:identityID];
     }
 }
 
 - (NSString *)getUserIdentity {
     if (_userIdentity) {
-        _userIdentity = [BNCPreferenceHelper readStringFromDefaults:KEY_IDENTITY];
+        _userIdentity = [self readStringFromDefaults:BRANCH_PREFS_KEY_IDENTITY];
     }
 
     return _userIdentity;
@@ -239,13 +242,13 @@ NSString * const BRANCH_PREFS_KEY_UNIQUE_BASE = @"bnc_unique_base_";
 - (void)setUserIdentity:(NSString *)userIdentity {
     if (![_userIdentity isEqualToString:userIdentity]) {
         _userIdentity = userIdentity;
-        [BNCPreferenceHelper writeObjectToDefaults:KEY_IDENTITY value:userIdentity];
+        [self writeObjectToDefaults:BRANCH_PREFS_KEY_IDENTITY value:userIdentity];
     }
 }
 
 - (NSString *)getLinkClickIdentifier {
     if (!_linkClickIdentifier) {
-        _linkClickIdentifier = [BNCPreferenceHelper readStringFromDefaults:KEY_LINK_CLICK_IDENTIFIER];
+        _linkClickIdentifier = [self readStringFromDefaults:BRANCH_PREFS_KEY_LINK_CLICK_IDENTIFIER];
     }
 
     return _linkClickIdentifier;
@@ -254,13 +257,13 @@ NSString * const BRANCH_PREFS_KEY_UNIQUE_BASE = @"bnc_unique_base_";
 - (void)setLinkClickIdentifier:(NSString *)linkClickIdentifier {
     if (![_linkClickIdentifier isEqualToString:linkClickIdentifier]) {
         _linkClickIdentifier = linkClickIdentifier;
-        [BNCPreferenceHelper writeObjectToDefaults:KEY_LINK_CLICK_IDENTIFIER value:linkClickIdentifier];
+        [self writeObjectToDefaults:BRANCH_PREFS_KEY_LINK_CLICK_IDENTIFIER value:linkClickIdentifier];
     }
 }
 
 - (NSString *)getSessionParams {
     if (_sessionParams) {
-        _sessionParams = [BNCPreferenceHelper readStringFromDefaults:KEY_SESSION_PARAMS];
+        _sessionParams = [self readStringFromDefaults:BRANCH_PREFS_KEY_SESSION_PARAMS];
     }
     
     return _sessionParams;
@@ -269,13 +272,13 @@ NSString * const BRANCH_PREFS_KEY_UNIQUE_BASE = @"bnc_unique_base_";
 - (void)setSessionParams:(NSString *)sessionParams {
     if (![_sessionParams isEqualToString:sessionParams]) {
         _sessionParams = sessionParams;
-        [BNCPreferenceHelper writeObjectToDefaults:KEY_SESSION_PARAMS value:sessionParams];
+        [self writeObjectToDefaults:BRANCH_PREFS_KEY_SESSION_PARAMS value:sessionParams];
     }
 }
 
 - (NSString *)getInstallParams {
     if (!_installParams) {
-        _installParams = [BNCPreferenceHelper readStringFromDefaults:KEY_INSTALL_PARAMS];
+        _installParams = [self readStringFromDefaults:BRANCH_PREFS_KEY_INSTALL_PARAMS];
     }
     
     return _installParams;
@@ -284,13 +287,13 @@ NSString * const BRANCH_PREFS_KEY_UNIQUE_BASE = @"bnc_unique_base_";
 - (void)setInstallParams:(NSString *)installParams {
     if (![_installParams isEqualToString:installParams]) {
         _installParams = installParams;
-        [BNCPreferenceHelper writeObjectToDefaults:KEY_INSTALL_PARAMS value:installParams];
+        [self writeObjectToDefaults:BRANCH_PREFS_KEY_INSTALL_PARAMS value:installParams];
     }
 }
 
 - (NSString *)getUserURL {
     if (!_userUrl) {
-        _userUrl = [BNCPreferenceHelper readStringFromDefaults:KEY_USER_URL];
+        _userUrl = [self readStringFromDefaults:BRANCH_PREFS_KEY_USER_URL];
     }
     
     return _userUrl;
@@ -299,7 +302,7 @@ NSString * const BRANCH_PREFS_KEY_UNIQUE_BASE = @"bnc_unique_base_";
 - (void)setUserURL:(NSString *)userUrl {
     if (![_userUrl isEqualToString:userUrl]) {
         _userUrl = userUrl;
-        [BNCPreferenceHelper writeObjectToDefaults:KEY_USER_URL value:userUrl];
+        [self writeObjectToDefaults:BRANCH_PREFS_KEY_USER_URL value:userUrl];
     }
 }
 
@@ -310,16 +313,16 @@ NSString * const BRANCH_PREFS_KEY_UNIQUE_BASE = @"bnc_unique_base_";
 - (void)setIsReferrable:(BOOL)isReferrable {
     if (_isReferrable != isReferrable) {
         _isReferrable = isReferrable;
-        [BNCPreferenceHelper writeBoolToDefaults:KEY_IS_REFERRABLE value:isReferrable];
+        [self writeBoolToDefaults:BRANCH_PREFS_KEY_IS_REFERRABLE value:isReferrable];
     }
 }
 
 - (void)setAppListCheckDone {
-    [BNCPreferenceHelper writeObjectToDefaults:KEY_APP_LIST_CHECK value:[NSDate date]];
+    [self writeObjectToDefaults:BRANCH_PREFS_KEY_APP_LIST_CHECK value:[NSDate date]];
 }
 
 - (BOOL)getNeedAppListCheck {
-    NSDate *lastDate = (NSDate *)[BNCPreferenceHelper readObjectFromDefaults:KEY_APP_LIST_CHECK];
+    NSDate *lastDate = (NSDate *)[self readObjectFromDefaults:BRANCH_PREFS_KEY_APP_LIST_CHECK];
     if (lastDate) {
         NSDate *currDate = [NSDate date];
         NSTimeInterval diff = [currDate timeIntervalSinceDate:lastDate];
@@ -339,7 +342,7 @@ NSString * const BRANCH_PREFS_KEY_UNIQUE_BASE = @"bnc_unique_base_";
 
 - (NSDictionary *)getCreditsDictionary {
     if (!_creditsDictionary) {
-        _creditsDictionary = [[BNCPreferenceHelper readObjectFromDefaults:KEY_CREDITS] mutableCopy];
+        _creditsDictionary = [[self readObjectFromDefaults:BRANCH_PREFS_KEY_CREDITS] mutableCopy];
         
         if (_creditsDictionary) {
             _creditsDictionary = [[NSMutableDictionary alloc] init];
@@ -354,9 +357,9 @@ NSString * const BRANCH_PREFS_KEY_UNIQUE_BASE = @"bnc_unique_base_";
 }
 
 - (void)setCreditCount:(NSInteger)count forBucket:(NSString *)bucket {
-    self.creditsDictionary[[KEY_CREDIT_BASE stringByAppendingString:bucket]] = @(count);
+    self.creditsDictionary[[BRANCH_PREFS_KEY_CREDIT_BASE stringByAppendingString:bucket]] = @(count);
 
-    [BNCPreferenceHelper writeObjectToDefaults:KEY_CREDITS value:self.creditsDictionary];
+    [self writeObjectToDefaults:BRANCH_PREFS_KEY_CREDITS value:self.creditsDictionary];
 }
 
 - (NSInteger)getCreditCount {
@@ -364,14 +367,14 @@ NSString * const BRANCH_PREFS_KEY_UNIQUE_BASE = @"bnc_unique_base_";
 }
 
 - (NSInteger)getCreditCountForBucket:(NSString *)bucket {
-    return [self.creditsDictionary[[KEY_CREDIT_BASE stringByAppendingString:bucket]] integerValue];
+    return [self.creditsDictionary[[BRANCH_PREFS_KEY_CREDIT_BASE stringByAppendingString:bucket]] integerValue];
 }
 
 #pragma mark - Count Storage
 
 - (NSDictionary *)getCountsDictionary {
     if (!_countsDictionary) {
-        _countsDictionary = [[BNCPreferenceHelper readObjectFromDefaults:KEY_COUNTS] mutableCopy];
+        _countsDictionary = [[self readObjectFromDefaults:BRANCH_PREFS_KEY_COUNTS] mutableCopy];
         
         if (_countsDictionary) {
             _countsDictionary = [[NSMutableDictionary alloc] init];
@@ -382,74 +385,100 @@ NSString * const BRANCH_PREFS_KEY_UNIQUE_BASE = @"bnc_unique_base_";
 }
 
 - (void)setActionTotalCount:(NSString *)action withCount:(NSInteger)count {
-    self.countsDictionary[[KEY_TOTAL_BASE stringByAppendingString:action]] = @(count);
+    self.countsDictionary[[BRANCH_PREFS_KEY_TOTAL_BASE stringByAppendingString:action]] = @(count);
     
-    [BNCPreferenceHelper writeObjectToDefaults:KEY_COUNTS value:self.countsDictionary];
+    [self writeObjectToDefaults:BRANCH_PREFS_KEY_COUNTS value:self.countsDictionary];
 }
 
 - (void)setActionUniqueCount:(NSString *)action withCount:(NSInteger)count {
-    self.countsDictionary[[KEY_UNIQUE_BASE stringByAppendingString:action]] = @(count);
+    self.countsDictionary[[BRANCH_PREFS_KEY_UNIQUE_BASE stringByAppendingString:action]] = @(count);
 
-    [BNCPreferenceHelper writeObjectToDefaults:KEY_COUNTS value:self.countsDictionary];
+    [self writeObjectToDefaults:BRANCH_PREFS_KEY_COUNTS value:self.countsDictionary];
 }
 
 - (NSInteger)getActionTotalCount:(NSString *)action {
-    return [self.countsDictionary[[KEY_TOTAL_BASE stringByAppendingString:action]] integerValue];
+    return [self.countsDictionary[[BRANCH_PREFS_KEY_TOTAL_BASE stringByAppendingString:action]] integerValue];
 }
 
 - (NSInteger)getActionUniqueCount:(NSString *)action {
-    return [self.countsDictionary[[KEY_UNIQUE_BASE stringByAppendingString:action]] integerValue];
+    return [self.countsDictionary[[BRANCH_PREFS_KEY_UNIQUE_BASE stringByAppendingString:action]] integerValue];
 }
 
-#pragma mark - Writing To Defaults
+#pragma mark - Writing To Persistence
 
-+ (void)writeIntegerToDefaults:(NSString *)key value:(NSInteger)value {
-    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-    [defaults setInteger:value forKey:key];
-    [defaults synchronize];
+- (void)writeIntegerToDefaults:(NSString *)key value:(NSInteger)value {
+    self.persistenceDict[key] = @(value);
+    [self persistPrefsToDisk];
 }
 
-+ (void)writeBoolToDefaults:(NSString *)key value:(BOOL)value {
-    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-    [defaults setBool:value forKey:key];
-    [defaults synchronize];
+- (void)writeBoolToDefaults:(NSString *)key value:(BOOL)value {
+    self.persistenceDict[key] = @(value);
+    [self persistPrefsToDisk];
 }
 
-+ (void)writeObjectToDefaults:(NSString *)key value:(NSObject *)value {
-    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-    [defaults setObject:value forKey:key];
-    [defaults synchronize];
+- (void)writeObjectToDefaults:(NSString *)key value:(NSObject *)value {
+    if (value) {
+        self.persistenceDict[key] = value;
+    }
+    else {
+        [self.persistenceDict removeObjectForKey:key];
+    }
+
+    [self persistPrefsToDisk];
 }
 
-#pragma mark - Reading From Defaults
+- (void)persistPrefsToDisk {
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        if (![NSKeyedArchiver archiveRootObject:self.persistenceDict toFile:[self prefsFile]]) {
+            NSLog(@"[Branch Warning] Failed to persist preferences to disk");
+        }
+    });
+}
 
-+ (NSObject *)readObjectFromDefaults:(NSString *)key {
-    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-    NSObject *obj = [defaults objectForKey:key];
+#pragma mark - Reading From Persistence
+
+- (NSMutableDictionary *)persistenceDict {
+    if (!_persistenceDict) {
+        NSDictionary *persistenceDict = [NSKeyedUnarchiver unarchiveObjectWithFile:[self prefsFile]];
+
+        if (persistenceDict) {
+            _persistenceDict = [persistenceDict mutableCopy];
+        }
+        else {
+            _persistenceDict = [[NSMutableDictionary alloc] init];
+        }
+    }
+    
+    return _persistenceDict;
+}
+
+- (NSObject *)readObjectFromDefaults:(NSString *)key {
+    NSObject *obj = self.persistenceDict[key];
     return obj;
 }
 
-+ (NSString *)readStringFromDefaults:(NSString *)key {
-    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-    NSString *str = [defaults stringForKey:key];
+- (NSString *)readStringFromDefaults:(NSString *)key {
+    NSString *str = self.persistenceDict[key];
     return str;
 }
 
-+ (BOOL)readBoolFromDefaults:(NSString *)key {
-    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-    BOOL boo = [defaults boolForKey:key];
+- (BOOL)readBoolFromDefaults:(NSString *)key {
+    BOOL boo = [self.persistenceDict[key] boolValue];
     return boo;
 }
 
-+ (NSInteger)readIntegerFromDefaults:(NSString *)key {
-    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-    NSNumber *number = [defaults objectForKey:key];
+- (NSInteger)readIntegerFromDefaults:(NSString *)key {
+    NSNumber *number = self.persistenceDict[key];
     
     if (number) {
         return [number integerValue];
     }
     
     return NSNotFound;
+}
+
+- (NSString *)prefsFile {
+    return [[NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES) firstObject] stringByAppendingPathComponent:BRANCH_PREFS_FILE];
 }
 
 @end

--- a/Branch-SDK/Branch-SDK/BNCPreferenceHelper.m
+++ b/Branch-SDK/Branch-SDK/BNCPreferenceHelper.m
@@ -348,7 +348,7 @@ NSString * const BRANCH_PREFS_KEY_UNIQUE_BASE = @"bnc_unique_base_";
     if (!_creditsDictionary) {
         _creditsDictionary = [[self readObjectFromDefaults:BRANCH_PREFS_KEY_CREDITS] mutableCopy];
         
-        if (_creditsDictionary) {
+        if (!_creditsDictionary) {
             _creditsDictionary = [[NSMutableDictionary alloc] init];
         }
     }
@@ -380,7 +380,7 @@ NSString * const BRANCH_PREFS_KEY_UNIQUE_BASE = @"bnc_unique_base_";
     if (!_countsDictionary) {
         _countsDictionary = [[self readObjectFromDefaults:BRANCH_PREFS_KEY_COUNTS] mutableCopy];
         
-        if (_countsDictionary) {
+        if (!_countsDictionary) {
             _countsDictionary = [[NSMutableDictionary alloc] init];
         }
     }

--- a/Branch-SDK/Branch-SDK/BNCPreferenceHelper.m
+++ b/Branch-SDK/Branch-SDK/BNCPreferenceHelper.m
@@ -51,6 +51,10 @@ NSString * const BRANCH_PREFS_KEY_UNIQUE_BASE = @"bnc_unique_base_";
 
 @implementation BNCPreferenceHelper
 
+@synthesize branchKey = _branchKey, appKey = _appKey, lastRunBranchKey = _lastRunBranchKey, appVersion = _appVersion, deviceFingerprintID = _deviceFingerprintID, sessionID = _sessionID,
+            identityID = _identityID, linkClickIdentifier = _linkClickIdentifier, userUrl = _userUrl, userIdentity = _userIdentity, sessionParams = _sessionParams, installParams = _installParams,
+            isReferrable = _isReferrable, isDebug = _isDebug, isConnectedToRemoteDebug = _isConnectedToRemoteDebug, retryCount = _retryCount, retryInterval = _retryInterval, timeout = _timeout;
+
 + (BNCPreferenceHelper *)preferenceHelper {
     static BNCPreferenceHelper *preferenceHelper;
     static dispatch_once_t onceToken;
@@ -114,7 +118,7 @@ NSString * const BRANCH_PREFS_KEY_UNIQUE_BASE = @"bnc_unique_base_";
 
 #pragma mark - Preference Storage
 
-- (NSString *)getAppKey {
+- (NSString *)appKey {
     if (!_appKey) {
         _appKey = [[[NSBundle mainBundle] infoDictionary] objectForKey:BRANCH_PREFS_KEY_APP_KEY];
     }
@@ -156,7 +160,7 @@ NSString * const BRANCH_PREFS_KEY_UNIQUE_BASE = @"bnc_unique_base_";
     _branchKey = branchKey;
 }
 
-- (NSString *)getLastRunBranchKey {
+- (NSString *)lastRunBranchKey {
     if (!_lastRunBranchKey) {
         _lastRunBranchKey = [self readStringFromDefaults:BRANCH_PREFS_KEY_LAST_RUN_BRANCH_KEY];
     }
@@ -171,7 +175,7 @@ NSString * const BRANCH_PREFS_KEY_UNIQUE_BASE = @"bnc_unique_base_";
     }
 }
 
-- (NSString *)getAppVersion {
+- (NSString *)appVersion {
     if (!_appVersion) {
         _appVersion = [self readStringFromDefaults:BRANCH_PREFS_KEY_APP_VERSION];
     }
@@ -186,7 +190,7 @@ NSString * const BRANCH_PREFS_KEY_UNIQUE_BASE = @"bnc_unique_base_";
     }
 }
 
-- (NSString *)getDeviceFingerprintID {
+- (NSString *)deviceFingerprintID {
     if (!_deviceFingerprintID) {
         _deviceFingerprintID = [self readStringFromDefaults:BRANCH_PREFS_KEY_DEVICE_FINGERPRINT_ID];
     }
@@ -201,7 +205,7 @@ NSString * const BRANCH_PREFS_KEY_UNIQUE_BASE = @"bnc_unique_base_";
     }
 }
 
-- (NSString *)getSessionID {
+- (NSString *)sessionID {
     if (!_sessionID) {
         _sessionID = [self readStringFromDefaults:BRANCH_PREFS_KEY_SESSION_ID];
     }
@@ -216,7 +220,7 @@ NSString * const BRANCH_PREFS_KEY_UNIQUE_BASE = @"bnc_unique_base_";
     }
 }
 
-- (NSString *)getIdentityID {
+- (NSString *)identityID {
     if (!_identityID) {
         _identityID = [self readStringFromDefaults:BRANCH_PREFS_KEY_IDENTITY_ID];
     }
@@ -231,7 +235,7 @@ NSString * const BRANCH_PREFS_KEY_UNIQUE_BASE = @"bnc_unique_base_";
     }
 }
 
-- (NSString *)getUserIdentity {
+- (NSString *)userIdentity {
     if (_userIdentity) {
         _userIdentity = [self readStringFromDefaults:BRANCH_PREFS_KEY_IDENTITY];
     }
@@ -246,7 +250,7 @@ NSString * const BRANCH_PREFS_KEY_UNIQUE_BASE = @"bnc_unique_base_";
     }
 }
 
-- (NSString *)getLinkClickIdentifier {
+- (NSString *)linkClickIdentifier {
     if (!_linkClickIdentifier) {
         _linkClickIdentifier = [self readStringFromDefaults:BRANCH_PREFS_KEY_LINK_CLICK_IDENTIFIER];
     }
@@ -261,7 +265,7 @@ NSString * const BRANCH_PREFS_KEY_UNIQUE_BASE = @"bnc_unique_base_";
     }
 }
 
-- (NSString *)getSessionParams {
+- (NSString *)sessionParams {
     if (_sessionParams) {
         _sessionParams = [self readStringFromDefaults:BRANCH_PREFS_KEY_SESSION_PARAMS];
     }
@@ -276,7 +280,7 @@ NSString * const BRANCH_PREFS_KEY_UNIQUE_BASE = @"bnc_unique_base_";
     }
 }
 
-- (NSString *)getInstallParams {
+- (NSString *)installParams {
     if (!_installParams) {
         _installParams = [self readStringFromDefaults:BRANCH_PREFS_KEY_INSTALL_PARAMS];
     }
@@ -291,7 +295,7 @@ NSString * const BRANCH_PREFS_KEY_UNIQUE_BASE = @"bnc_unique_base_";
     }
 }
 
-- (NSString *)getUserURL {
+- (NSString *)userURL {
     if (!_userUrl) {
         _userUrl = [self readStringFromDefaults:BRANCH_PREFS_KEY_USER_URL];
     }
@@ -306,7 +310,7 @@ NSString * const BRANCH_PREFS_KEY_UNIQUE_BASE = @"bnc_unique_base_";
     }
 }
 
-- (BOOL)getIsReferrable {
+- (BOOL)isReferrable {
     return _isReferrable;
 }
 
@@ -340,7 +344,7 @@ NSString * const BRANCH_PREFS_KEY_UNIQUE_BASE = @"bnc_unique_base_";
 
 #pragma mark - Credit Storage
 
-- (NSMutableDictionary *)getCreditsDictionary {
+- (NSMutableDictionary *)creditsDictionary {
     if (!_creditsDictionary) {
         _creditsDictionary = [[self readObjectFromDefaults:BRANCH_PREFS_KEY_CREDITS] mutableCopy];
         
@@ -372,7 +376,7 @@ NSString * const BRANCH_PREFS_KEY_UNIQUE_BASE = @"bnc_unique_base_";
 
 #pragma mark - Count Storage
 
-- (NSMutableDictionary *)getCountsDictionary {
+- (NSMutableDictionary *)countsDictionary {
     if (!_countsDictionary) {
         _countsDictionary = [[self readObjectFromDefaults:BRANCH_PREFS_KEY_COUNTS] mutableCopy];
         

--- a/Branch-SDK/Branch-SDK/BNCPreferenceHelper.m
+++ b/Branch-SDK/Branch-SDK/BNCPreferenceHelper.m
@@ -340,7 +340,7 @@ NSString * const BRANCH_PREFS_KEY_UNIQUE_BASE = @"bnc_unique_base_";
 
 #pragma mark - Credit Storage
 
-- (NSDictionary *)getCreditsDictionary {
+- (NSMutableDictionary *)getCreditsDictionary {
     if (!_creditsDictionary) {
         _creditsDictionary = [[self readObjectFromDefaults:BRANCH_PREFS_KEY_CREDITS] mutableCopy];
         
@@ -372,7 +372,7 @@ NSString * const BRANCH_PREFS_KEY_UNIQUE_BASE = @"bnc_unique_base_";
 
 #pragma mark - Count Storage
 
-- (NSDictionary *)getCountsDictionary {
+- (NSMutableDictionary *)getCountsDictionary {
     if (!_countsDictionary) {
         _countsDictionary = [[self readObjectFromDefaults:BRANCH_PREFS_KEY_COUNTS] mutableCopy];
         

--- a/Branch-SDK/Branch-SDK/BNCPreferenceHelper.m
+++ b/Branch-SDK/Branch-SDK/BNCPreferenceHelper.m
@@ -15,28 +15,28 @@ static const NSInteger DEFAULT_RETRY_INTERVAL = 0;
 static const NSInteger DEFAULT_RETRY_COUNT = 1;
 static const NSInteger APP_READ_INTERVAL = 520000;
 
-static NSString *KEY_APP_KEY = @"bnc_app_key";
-static NSString *KEY_APP_VERSION = @"bnc_app_version";
-static NSString *KEY_LAST_RUN_BRANCH_KEY = @"bnc_last_run_branch_key";
+NSString * const BRANCH_PREFS_KEY_APP_KEY = @"bnc_app_key";
+NSString * const BRANCH_PREFS_KEY_APP_VERSION = @"bnc_app_version";
+NSString * const BRANCH_PREFS_KEY_LAST_RUN_BRANCH_KEY = @"bnc_last_run_branch_key";
 
-static NSString *KEY_DEVICE_FINGERPRINT_ID = @"bnc_device_fingerprint_id";
-static NSString *KEY_SESSION_ID = @"bnc_session_id";
-static NSString *KEY_IDENTITY_ID = @"bnc_identity_id";
-static NSString *KEY_IDENTITY = @"bnc_identity";
-static NSString *KEY_LINK_CLICK_IDENTIFIER = @"bnc_link_click_identifier";
-static NSString *KEY_LINK_CLICK_ID = @"bnc_link_click_id";
-static NSString *KEY_SESSION_PARAMS = @"bnc_session_params";
-static NSString *KEY_INSTALL_PARAMS = @"bnc_install_params";
-static NSString *KEY_USER_URL = @"bnc_user_url";
-static NSString *KEY_IS_REFERRABLE = @"bnc_is_referrable";
-static NSString *KEY_APP_LIST_CHECK = @"bnc_app_list_check";
+NSString * const BRANCH_PREFS_KEY_DEVICE_FINGERPRINT_ID = @"bnc_device_fingerprint_id";
+NSString * const BRANCH_PREFS_KEY_SESSION_ID = @"bnc_session_id";
+NSString * const BRANCH_PREFS_KEY_IDENTITY_ID = @"bnc_identity_id";
+NSString * const BRANCH_PREFS_KEY_IDENTITY = @"bnc_identity";
+NSString * const BRANCH_PREFS_KEY_LINK_CLICK_IDENTIFIER = @"bnc_link_click_identifier";
+NSString * const BRANCH_PREFS_KEY_LINK_CLICK_ID = @"bnc_link_click_id";
+NSString * const BRANCH_PREFS_KEY_SESSION_PARAMS = @"bnc_session_params";
+NSString * const BRANCH_PREFS_KEY_INSTALL_PARAMS = @"bnc_install_params";
+NSString * const BRANCH_PREFS_KEY_USER_URL = @"bnc_user_url";
+NSString * const BRANCH_PREFS_KEY_IS_REFERRABLE = @"bnc_is_referrable";
+NSString * const BRANCH_PREFS_KEY_APP_LIST_CHECK = @"bnc_app_list_check";
 
-static NSString *KEY_CREDITS = @"bnc_credits";
-static NSString *KEY_CREDIT_BASE = @"bnc_credit_base_";
+NSString * const BRANCH_PREFS_KEY_CREDITS = @"bnc_credits";
+NSString * const BRANCH_PREFS_KEY_CREDIT_BASE = @"bnc_credit_base_";
 
-static NSString *KEY_COUNTS = @"bnc_counts";
-static NSString *KEY_TOTAL_BASE = @"bnc_total_base_";
-static NSString *KEY_UNIQUE_BASE = @"bnc_unique_base_";
+NSString * const BRANCH_PREFS_KEY_COUNTS = @"bnc_counts";
+NSString * const BRANCH_PREFS_KEY_TOTAL_BASE = @"bnc_total_base_";
+NSString * const BRANCH_PREFS_KEY_UNIQUE_BASE = @"bnc_unique_base_";
 
 @interface BNCPreferenceHelper ()
 

--- a/Branch-SDK/Branch-SDK/BNCServerInterface.h
+++ b/Branch-SDK/Branch-SDK/BNCServerInterface.h
@@ -8,6 +8,7 @@
 
 #import <Foundation/Foundation.h>
 #import "BNCServerResponse.h"
+#import "BNCPreferenceHelper.h"
 
 typedef void (^BNCServerCallback)(BNCServerResponse *response, NSError *error);
 
@@ -17,6 +18,8 @@ static NSString *REQ_TAG_DEBUG_SCREEN = @"t_debug_screen";
 static NSString *REQ_TAG_DEBUG_DISCONNECT = @"t_debug_disconnect";
 
 @interface BNCServerInterface : NSObject
+
+@property (strong, nonatomic) BNCPreferenceHelper *preferenceHelper;
 
 - (BNCServerResponse *)getRequest:(NSDictionary *)params url:(NSString *)url key:(NSString *)key;
 - (BNCServerResponse *)getRequest:(NSDictionary *)params url:(NSString *)url key:(NSString *)key log:(BOOL)log;

--- a/Branch-SDK/Branch-SDK/BNCServerRequestQueue.m
+++ b/Branch-SDK/Branch-SDK/BNCServerRequestQueue.m
@@ -47,7 +47,7 @@ NSUInteger const BATCH_WRITE_TIMEOUT = 3;
 - (void)insert:(BNCServerRequest *)request at:(unsigned int)index {
     @synchronized(self.queue) {
         if (index > self.queue.count) {
-            [BNCPreferenceHelper log:FILE_NAME line:LINE_NUM message:@"Invalid queue operation: index out of bound!"];
+            [[BNCPreferenceHelper preferenceHelper] log:FILE_NAME line:LINE_NUM message:@"Invalid queue operation: index out of bound!"];
             return;
         }
         
@@ -76,7 +76,7 @@ NSUInteger const BATCH_WRITE_TIMEOUT = 3;
     BNCServerRequest *request = nil;
     @synchronized(self.queue) {
         if (index >= self.queue.count) {
-            [BNCPreferenceHelper log:FILE_NAME line:LINE_NUM message:@"Invalid queue operation: index out of bound!"];
+            [[BNCPreferenceHelper preferenceHelper] log:FILE_NAME line:LINE_NUM message:@"Invalid queue operation: index out of bound!"];
             return nil;
         }
         
@@ -99,7 +99,7 @@ NSUInteger const BATCH_WRITE_TIMEOUT = 3;
 
 - (BNCServerRequest *)peekAt:(unsigned int)index {
     if (index >= self.queue.count) {
-        [BNCPreferenceHelper log:FILE_NAME line:LINE_NUM message:@"Invalid queue operation: index out of bound!"];
+        [[BNCPreferenceHelper preferenceHelper] log:FILE_NAME line:LINE_NUM message:@"Invalid queue operation: index out of bound!"];
         return nil;
     }
     
@@ -247,7 +247,7 @@ NSUInteger const BATCH_WRITE_TIMEOUT = 3;
     dispatch_once(&onceToken, ^{
         sharedQueue = [[BNCServerRequestQueue alloc] init];
         sharedQueue.queue = [BNCServerRequestQueue retrieve];
-        [BNCPreferenceHelper log:FILE_NAME line:LINE_NUM message:@"Retrieved from Persist: %@", sharedQueue];
+        [[BNCPreferenceHelper preferenceHelper] log:FILE_NAME line:LINE_NUM message:@"Retrieved from Persist: %@", sharedQueue];
     });
     
     return sharedQueue;

--- a/Branch-SDK/Branch-SDK/BNCServerRequestQueue.m
+++ b/Branch-SDK/Branch-SDK/BNCServerRequestQueue.m
@@ -11,7 +11,7 @@
 #import "BranchCloseRequest.h"
 #import "BranchOpenRequest.h"
 
-NSString * const STORAGE_KEY = @"BNCServerRequestQueue";
+NSString * const BRANCH_QUEUE_FILE = @"BNCServerRequestQueue";
 NSUInteger const BATCH_WRITE_TIMEOUT = 3;
 
 @interface BNCServerRequestQueue()
@@ -19,8 +19,6 @@ NSUInteger const BATCH_WRITE_TIMEOUT = 3;
 @property (nonatomic, strong) NSMutableArray *queue;
 @property (nonatomic) dispatch_queue_t asyncQueue;
 @property (strong, nonatomic) NSTimer *writeTimer;
-
-+ (NSMutableArray *)retrieve;
 
 @end
 
@@ -196,46 +194,37 @@ NSUInteger const BATCH_WRITE_TIMEOUT = 3;
 - (void)persistToDisk {
     NSArray *requestsToPersist = [self.queue copy];
     dispatch_async(self.asyncQueue, ^{
-        NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-        NSMutableArray *arr = [[NSMutableArray alloc] init];
+        NSMutableArray *encodedRequests = [[NSMutableArray alloc] init];
         
         for (BNCServerRequest *req in requestsToPersist) {
             NSData *encodedReq = [NSKeyedArchiver archivedDataWithRootObject:req];
-            [arr addObject:encodedReq];
+            [encodedRequests addObject:encodedReq];
         }
         
-        [defaults setObject:arr forKey:STORAGE_KEY];
-        [defaults synchronize];
+        if (![NSKeyedArchiver archiveRootObject:encodedRequests toFile:[self queueFile]]) {
+            NSLog(@"[Branch Warning] Failed to persist queue to disk");
+        }
     });
 }
 
-+ (NSMutableArray *)retrieve {
+- (void)retrieve {
     NSMutableArray *queue = [[NSMutableArray alloc] init];
-    
-    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-    id data = [defaults objectForKey:STORAGE_KEY];
-    if (!data) {
-        return queue;
-    }
-    
-    NSArray *arr = (NSArray *)data;
-    for (NSData *encodedRequest in arr) {
-        if (encodedRequest) {
-            @try {
-                BNCServerRequest *request = [NSKeyedUnarchiver unarchiveObjectWithData:encodedRequest];
-                
-                // TODO figure out loading from disk
-                
-                if (![request isKindOfClass:[BranchCloseRequest class]]) {
-                    [queue addObject:request];
-                }
-            }
-            @catch (NSException* exception) {
-            }
+    NSArray *encodedRequests = [NSKeyedUnarchiver unarchiveObjectWithFile:[self queueFile]];
+
+    for (NSData *encodedRequest in encodedRequests) {
+        BNCServerRequest *request = [NSKeyedUnarchiver unarchiveObjectWithData:encodedRequest];
+        
+        // Throw out persisted close requests
+        if (![request isKindOfClass:[BranchCloseRequest class]]) {
+            [queue addObject:request];
         }
     }
     
-    return queue;
+    self.queue = queue;
+}
+
+- (NSString *)queueFile {
+    return [[NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES) firstObject] stringByAppendingPathComponent:BRANCH_QUEUE_FILE];
 }
 
 #pragma mark - Singleton method
@@ -246,7 +235,7 @@ NSUInteger const BATCH_WRITE_TIMEOUT = 3;
     
     dispatch_once(&onceToken, ^{
         sharedQueue = [[BNCServerRequestQueue alloc] init];
-        sharedQueue.queue = [BNCServerRequestQueue retrieve];
+        [sharedQueue retrieve];
         [[BNCPreferenceHelper preferenceHelper] log:FILE_NAME line:LINE_NUM message:@"Retrieved from Persist: %@", sharedQueue];
     });
     

--- a/Branch-SDK/Branch-SDK/BNCSystemObserver.m
+++ b/Branch-SDK/Branch-SDK/BNCSystemObserver.m
@@ -128,7 +128,7 @@
 }
 
 + (NSNumber *)getUpdateState {
-    NSString *storedAppVersion = [BNCPreferenceHelper getAppVersion];
+    NSString *storedAppVersion = [BNCPreferenceHelper preferenceHelper].appVersion;
     NSString *currentAppVersion = [BNCSystemObserver getAppVersion];
     NSFileManager *manager = [NSFileManager defaultManager];
     
@@ -167,7 +167,7 @@
 
 + (void)setUpdateState {
     NSString *currentAppVersion = [BNCSystemObserver getAppVersion];
-    [BNCPreferenceHelper setAppVersion:currentAppVersion];
+    [BNCPreferenceHelper preferenceHelper].appVersion = currentAppVersion;
 }
 
 + (NSString *)getOS {

--- a/Branch-SDK/Branch-SDK/Branch.h
+++ b/Branch-SDK/Branch-SDK/Branch.h
@@ -11,6 +11,7 @@
 #import "BNCServerInterface.h"
 #import "BNCServerRequestQueue.h"
 #import "BNCLinkCache.h"
+#import "BNCPreferenceHelper.h"
 
 /**
  `Branch` is the primary interface of the Branch iOS SDK. Currently, all interactions you will make are funneled through this class. It is not meant to be instantiated or subclassed, usage should be limited to the global instance.
@@ -1059,7 +1060,7 @@ typedef NS_ENUM(NSUInteger, BranchPromoCodeUsageType) {
  
  @warning This is meant for use internally only (exposed for the sake of testing) and should not be used by apps.
  */
-- (id)initWithInterface:(BNCServerInterface *)interface queue:(BNCServerRequestQueue *)queue cache:(BNCLinkCache *)cache key:(NSString *)key;
+- (id)initWithInterface:(BNCServerInterface *)interface queue:(BNCServerRequestQueue *)queue cache:(BNCLinkCache *)cache preferenceHelper:(BNCPreferenceHelper *)preferenceHelper key:(NSString *)key;
 
 /**
  Method for logging a message to the Branch server, used when remote debugging is enabled.

--- a/Branch-SDK/Branch-SDK/Branch.m
+++ b/Branch-SDK/Branch-SDK/Branch.m
@@ -147,6 +147,7 @@ static int BNCDebugTriggerFingersSimulator = 2;
 - (id)initWithInterface:(BNCServerInterface *)interface queue:(BNCServerRequestQueue *)queue cache:(BNCLinkCache *)cache preferenceHelper:(BNCPreferenceHelper *)preferenceHelper key:(NSString *)key {
     if (self = [super init]) {
         _bServerInterface = interface;
+        _bServerInterface.preferenceHelper = preferenceHelper;
         _requestQueue = queue;
         _linkCache = cache;
         _preferenceHelper = preferenceHelper;

--- a/Branch-SDK/Branch-SDK/Branch.m
+++ b/Branch-SDK/Branch-SDK/Branch.m
@@ -939,7 +939,7 @@ static int BNCDebugTriggerFingersSimulator = 2;
     if (self.isInitialized) {
         self.isInitialized = NO;
 
-        if (![self.requestQueue containsClose]) {
+        if ([self hasSession] && ![self.requestQueue containsClose]) {
             BranchCloseRequest *req = [[BranchCloseRequest alloc] init];
             [self.requestQueue enqueue:req];
         }

--- a/Branch-SDK/Branch-SDK/BranchApplyPromoCodeRequest.m
+++ b/Branch-SDK/Branch-SDK/BranchApplyPromoCodeRequest.m
@@ -31,14 +31,15 @@
 }
 
 - (void)makeRequest:(BNCServerInterface *)serverInterface key:(NSString *)key callback:(BNCServerCallback)callback {
+    BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper preferenceHelper];
     NSDictionary *params = @{
-        @"identity_id": [BNCPreferenceHelper getIdentityID],
-        @"device_fingerprint_id": [BNCPreferenceHelper getDeviceFingerprintID],
-        @"session_id": [BNCPreferenceHelper getSessionID]
+        @"identity_id": preferenceHelper.identityID,
+        @"device_fingerprint_id": preferenceHelper.deviceFingerprintID,
+        @"session_id": preferenceHelper.sessionID
     };
     
     NSString *endpoint = self.useOld ? @"applycode/" : @"apply-promo-code/";
-    NSString *url = [[BNCPreferenceHelper getAPIURL:endpoint] stringByAppendingString:self.code];
+    NSString *url = [[preferenceHelper getAPIURL:endpoint] stringByAppendingString:self.code];
     [serverInterface postRequest:params url:url key:key callback:callback];
 }
 

--- a/Branch-SDK/Branch-SDK/BranchCloseRequest.m
+++ b/Branch-SDK/Branch-SDK/BranchCloseRequest.m
@@ -12,10 +12,12 @@
 @implementation BranchCloseRequest
 
 - (void)makeRequest:(BNCServerInterface *)serverInterface key:(NSString *)key callback:(BNCServerCallback)callback {
+    BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper preferenceHelper];
+
     // TODO remove this hack.
-    id identityId = [BNCPreferenceHelper getIdentityID] ?: [NSNull null];
-    id sessionId = [BNCPreferenceHelper getSessionID] ?: [NSNull null];
-    id fingerprintId = [BNCPreferenceHelper getDeviceFingerprintID] ?: [NSNull null];
+    id identityId = preferenceHelper.identityID ?: [NSNull null];
+    id sessionId = preferenceHelper.sessionID ?: [NSNull null];
+    id fingerprintId = preferenceHelper.deviceFingerprintID ?: [NSNull null];
 
     NSDictionary *params = @{
         @"identity_id": identityId,
@@ -23,7 +25,7 @@
         @"device_fingerprint_id": fingerprintId
     };
     
-    [serverInterface postRequest:params url:[BNCPreferenceHelper getAPIURL:@"close"] key:key callback:callback];
+    [serverInterface postRequest:params url:[preferenceHelper getAPIURL:@"close"] key:key callback:callback];
 }
 
 - (void)processResponse:(BNCServerResponse *)response error:(NSError *)error {

--- a/Branch-SDK/Branch-SDK/BranchConnectDebugRequest.m
+++ b/Branch-SDK/Branch-SDK/BranchConnectDebugRequest.m
@@ -27,8 +27,10 @@
 }
 
 - (void)makeRequest:(BNCServerInterface *)serverInterface key:(NSString *)key callback:(BNCServerCallback)callback {
+    BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper preferenceHelper];
+
     NSDictionary *params = @{
-        @"device_fingerprint_id": [BNCPreferenceHelper getDeviceFingerprintID],
+        @"device_fingerprint_id": preferenceHelper.deviceFingerprintID,
         @"device_name": [BNCSystemObserver getDeviceName],
         @"os": [BNCSystemObserver getOS],
         @"os_version": [BNCSystemObserver getOSVersion],
@@ -36,7 +38,7 @@
         @"is_simulator": @([BNCSystemObserver isSimulator])
     };
     
-    [serverInterface postRequest:params url:[BNCPreferenceHelper getAPIURL:@"debug/connect"] key:key log:NO callback:callback];
+    [serverInterface postRequest:params url:[preferenceHelper getAPIURL:@"debug/connect"] key:key log:NO callback:callback];
 }
 
 - (void)processResponse:(BNCServerResponse *)response error:(NSError *)error {
@@ -44,7 +46,7 @@
         NSLog(@"Failed to connect to debug: %@", error);
     }
     else {
-        [BNCPreferenceHelper setConnectedToRemoteDebug:YES];
+        [BNCPreferenceHelper preferenceHelper].isConnectedToRemoteDebug = YES;
 
         if (self.callback) {
             self.callback(YES, nil);

--- a/Branch-SDK/Branch-SDK/BranchCreditHistoryRequest.m
+++ b/Branch-SDK/Branch-SDK/BranchCreditHistoryRequest.m
@@ -36,9 +36,10 @@
 - (void)makeRequest:(BNCServerInterface *)serverInterface key:(NSString *)key callback:(BNCServerCallback)callback {
     NSMutableDictionary *params = [[NSMutableDictionary alloc] init];
     
-    params[@"device_fingerprint_id"] = [BNCPreferenceHelper getDeviceFingerprintID];
-    params[@"identity_id"] = [BNCPreferenceHelper getIdentityID];
-    params[@"session_id"] = [BNCPreferenceHelper getSessionID];
+    BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper preferenceHelper];
+    params[@"device_fingerprint_id"] = preferenceHelper.deviceFingerprintID;
+    params[@"identity_id"] = preferenceHelper.identityID;
+    params[@"session_id"] = preferenceHelper.sessionID;
     params[@"length"] = @(self.length);
     params[@"direction"] = self.order == BranchMostRecentFirst ? @"desc" : @"asc";
 
@@ -50,7 +51,7 @@
         params[@"begin_after_id"] = self.creditTransactionId;
     }
     
-    [serverInterface postRequest:params url:[BNCPreferenceHelper getAPIURL:@"credithistory"] key:key callback:callback];
+    [serverInterface postRequest:params url:[preferenceHelper getAPIURL:@"credithistory"] key:key callback:callback];
 }
 
 - (void)processResponse:(BNCServerResponse *)response error:(NSError *)error {

--- a/Branch-SDK/Branch-SDK/BranchDisconnectDebugRequest.m
+++ b/Branch-SDK/Branch-SDK/BranchDisconnectDebugRequest.m
@@ -13,14 +13,14 @@
 
 - (void)makeRequest:(BNCServerInterface *)serverInterface key:(NSString *)key callback:(BNCServerCallback)callback {
     NSDictionary *params = @{
-        @"device_fingerprint_id": [BNCPreferenceHelper getDeviceFingerprintID]
+        @"device_fingerprint_id": [BNCPreferenceHelper preferenceHelper].deviceFingerprintID
     };
 
-    [serverInterface postRequest:params url:[BNCPreferenceHelper getAPIURL:@"debug/disconnect"] key:key log:NO callback:callback];
+    [serverInterface postRequest:params url:[[BNCPreferenceHelper preferenceHelper] getAPIURL:@"debug/disconnect"] key:key log:NO callback:callback];
 }
 
 - (void)processResponse:(BNCServerResponse *)response error:(NSError *)error {
-    [BNCPreferenceHelper setConnectedToRemoteDebug:NO];
+    [BNCPreferenceHelper preferenceHelper].isConnectedToRemoteDebug = NO;
 }
 
 @end

--- a/Branch-SDK/Branch-SDK/BranchGetAppListRequest.m
+++ b/Branch-SDK/Branch-SDK/BranchGetAppListRequest.m
@@ -26,7 +26,7 @@
 }
 
 - (void)makeRequest:(BNCServerInterface *)serverInterface key:(NSString *)key callback:(BNCServerCallback)callback {
-    [serverInterface getRequest:nil url:[BNCPreferenceHelper getAPIURL:@"applist"] key:key callback:callback];
+    [serverInterface getRequest:nil url:[[BNCPreferenceHelper preferenceHelper] getAPIURL:@"applist"] key:key callback:callback];
 }
 
 - (void)processResponse:(BNCServerResponse *)response error:(NSError *)error {
@@ -37,7 +37,7 @@
         return;
     }
     
-    [BNCPreferenceHelper log:FILE_NAME line:LINE_NUM message:@"returned from app check with %@", response.data];
+    [[BNCPreferenceHelper preferenceHelper] log:FILE_NAME line:LINE_NUM message:@"returned from app check with %@", response.data];
     
     if (self.callback) {
         self.callback(response.data[@"potential_apps"], nil);

--- a/Branch-SDK/Branch-SDK/BranchGetPromoCodeRequest.m
+++ b/Branch-SDK/Branch-SDK/BranchGetPromoCodeRequest.m
@@ -44,9 +44,10 @@
 - (void)makeRequest:(BNCServerInterface *)serverInterface key:(NSString *)key callback:(BNCServerCallback)callback {
     NSMutableDictionary *params = [[NSMutableDictionary alloc] init];
     
-    params[@"device_fingerprint_id"] = [BNCPreferenceHelper getDeviceFingerprintID];
-    params[@"identity_id"] = [BNCPreferenceHelper getIdentityID];
-    params[@"session_id"] = [BNCPreferenceHelper getSessionID];
+    BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper preferenceHelper];
+    params[@"device_fingerprint_id"] = preferenceHelper.deviceFingerprintID;
+    params[@"identity_id"] = preferenceHelper.identityID;
+    params[@"session_id"] = preferenceHelper.sessionID;
     params[@"calculation_type"] = @(self.usageType);
     params[@"location"] = @(self.rewardLocation);
     params[@"type"] = @"credit";
@@ -64,7 +65,7 @@
     
     NSString *endpoint = self.useOld ? @"referralcode" : @"promo-code";
     
-    [serverInterface postRequest:params url:[BNCPreferenceHelper getAPIURL:endpoint] key:key callback:callback];
+    [serverInterface postRequest:params url:[preferenceHelper getAPIURL:endpoint] key:key callback:callback];
 }
 
 - (void)processResponse:(BNCServerResponse *)response error:(NSError *)error {

--- a/Branch-SDK/Branch-SDK/BranchInstallRequest.m
+++ b/Branch-SDK/Branch-SDK/BranchInstallRequest.m
@@ -17,10 +17,11 @@
 }
 
 - (void)makeRequest:(BNCServerInterface *)serverInterface key:(NSString *)key callback:(BNCServerCallback)callback {
+    BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper preferenceHelper];
     NSMutableDictionary *params = [[NSMutableDictionary alloc] init];
     
     BOOL isRealHardwareId;
-    NSString *hardwareId = [BNCSystemObserver getUniqueHardwareId:&isRealHardwareId andIsDebug:[BNCPreferenceHelper isDebug]];
+    NSString *hardwareId = [BNCSystemObserver getUniqueHardwareId:&isRealHardwareId andIsDebug:preferenceHelper.isDebug];
     if (hardwareId) {
         params[@"hardware_id"] = hardwareId;
         params[@"is_hardware_id_real"] = @(isRealHardwareId);
@@ -37,13 +38,13 @@
     [self safeSetValue:[BNCSystemObserver getScreenHeight] forKey:@"screen_height" onDict:params];
     [self safeSetValue:[BNCSystemObserver getDefaultUriScheme] forKey:@"uri_scheme" onDict:params];
     [self safeSetValue:[BNCSystemObserver getUpdateState] forKey:@"update" onDict:params];
-    [self safeSetValue:[BNCPreferenceHelper getLinkClickIdentifier] forKey:@"link_identifier" onDict:params];
+    [self safeSetValue:preferenceHelper.linkClickIdentifier forKey:@"link_identifier" onDict:params];
     
     params[@"ad_tracking_enabled"] = @([BNCSystemObserver adTrackingSafe]);
-    params[@"is_referrable"] = @([BNCPreferenceHelper getIsReferrable]);
-    params[@"debug"] = @([BNCPreferenceHelper isDebug]);
+    params[@"is_referrable"] = @(preferenceHelper.isReferrable);
+    params[@"debug"] = @(preferenceHelper.isDebug);
     
-    [serverInterface postRequest:params url:[BNCPreferenceHelper getAPIURL:@"install"] key:key callback:callback];
+    [serverInterface postRequest:params url:[preferenceHelper getAPIURL:@"install"] key:key callback:callback];
 }
 
 - (void)safeSetValue:(NSObject *)value forKey:(NSString *)key onDict:(NSMutableDictionary *)dict {

--- a/Branch-SDK/Branch-SDK/BranchLoadActionsRequest.m
+++ b/Branch-SDK/Branch-SDK/BranchLoadActionsRequest.m
@@ -26,8 +26,9 @@
 }
 
 - (void)makeRequest:(BNCServerInterface *)serverInterface key:(NSString *)key callback:(BNCServerCallback)callback {
-    NSString *endpoint = [NSString stringWithFormat:@"referrals/%@", [BNCPreferenceHelper getIdentityID]];
-    [serverInterface getRequest:nil url:[BNCPreferenceHelper getAPIURL:endpoint] key:key callback:callback];
+    BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper preferenceHelper];
+    NSString *endpoint = [NSString stringWithFormat:@"referrals/%@", preferenceHelper.identityID];
+    [serverInterface getRequest:nil url:[preferenceHelper getAPIURL:endpoint] key:key callback:callback];
 }
 
 - (void)processResponse:(BNCServerResponse *)response error:(NSError *)error {
@@ -44,12 +45,13 @@
         NSInteger total = [counts[@"total"] integerValue];
         NSInteger unique = [counts[@"unique"] integerValue];
         
-        if (total != [BNCPreferenceHelper getActionTotalCount:key] || unique != [BNCPreferenceHelper getActionUniqueCount:key]) {
+        BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper preferenceHelper];
+        if (total != [preferenceHelper getActionTotalCount:key] || unique != [preferenceHelper getActionUniqueCount:key]) {
             hasUpdated = YES;
         }
         
-        [BNCPreferenceHelper setActionTotalCount:key withCount:total];
-        [BNCPreferenceHelper setActionUniqueCount:key withCount:unique];
+        [preferenceHelper setActionTotalCount:key withCount:total];
+        [preferenceHelper setActionUniqueCount:key withCount:unique];
     }
     
     if (self.callback) {

--- a/Branch-SDK/Branch-SDK/BranchLoadRewardsRequest.m
+++ b/Branch-SDK/Branch-SDK/BranchLoadRewardsRequest.m
@@ -26,8 +26,9 @@
 }
 
 - (void)makeRequest:(BNCServerInterface *)serverInterface key:(NSString *)key callback:(BNCServerCallback)callback {
-    NSString *endpoint = [NSString stringWithFormat:@"credits/%@", [BNCPreferenceHelper getIdentityID]];
-    [serverInterface getRequest:nil url:[BNCPreferenceHelper getAPIURL:endpoint] key:key callback:callback];
+    BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper preferenceHelper];
+    NSString *endpoint = [NSString stringWithFormat:@"credits/%@", preferenceHelper.identityID];
+    [serverInterface getRequest:nil url:[preferenceHelper getAPIURL:endpoint] key:key callback:callback];
 }
 
 - (void)processResponse:(BNCServerResponse *)response error:(NSError *)error {
@@ -42,11 +43,12 @@
     for (NSString *key in response.data) {
         NSInteger credits = [response.data[key] integerValue];
         
-        if (credits != [BNCPreferenceHelper getCreditCountForBucket:key]) {
+        BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper preferenceHelper];
+        if (credits != [preferenceHelper getCreditCountForBucket:key]) {
             hasUpdated = YES;
         }
         
-        [BNCPreferenceHelper setCreditCount:credits forBucket:key];
+        [preferenceHelper setCreditCount:credits forBucket:key];
     }
     
     if (self.callback) {

--- a/Branch-SDK/Branch-SDK/BranchLogRequest.m
+++ b/Branch-SDK/Branch-SDK/BranchLogRequest.m
@@ -28,10 +28,10 @@
 - (void)makeRequest:(BNCServerInterface *)serverInterface key:(NSString *)key callback:(BNCServerCallback)callback {
     NSDictionary *params = @{
         @"log": self.log,
-        @"device_fingerprint_id": [BNCPreferenceHelper getDeviceFingerprintID]
+        @"device_fingerprint_id": [BNCPreferenceHelper preferenceHelper].deviceFingerprintID
     };
     
-    [serverInterface postRequest:params url:[BNCPreferenceHelper getAPIURL:@"debug/log"] key:key log:NO callback:callback];
+    [serverInterface postRequest:params url:[[BNCPreferenceHelper preferenceHelper] getAPIURL:@"debug/log"] key:key log:NO callback:callback];
 }
 
 - (void)processResponse:(BNCServerResponse *)response error:(NSError *)error {

--- a/Branch-SDK/Branch-SDK/BranchLogoutRequest.m
+++ b/Branch-SDK/Branch-SDK/BranchLogoutRequest.m
@@ -12,13 +12,15 @@
 @implementation BranchLogoutRequest
 
 - (void)makeRequest:(BNCServerInterface *)serverInterface key:(NSString *)key callback:(BNCServerCallback)callback {
+    BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper preferenceHelper];
+
     NSDictionary *params = @{
-        @"device_fingerprint_id": [BNCPreferenceHelper getDeviceFingerprintID],
-        @"session_id": [BNCPreferenceHelper getSessionID],
-        @"identity_id": [BNCPreferenceHelper getIdentityID]
+        @"device_fingerprint_id": preferenceHelper.deviceFingerprintID,
+        @"session_id": preferenceHelper.sessionID,
+        @"identity_id": preferenceHelper.identityID
     };
 
-    [serverInterface postRequest:params url:[BNCPreferenceHelper getAPIURL:@"logout"] key:key callback:callback];
+    [serverInterface postRequest:params url:[preferenceHelper getAPIURL:@"logout"] key:key callback:callback];
 }
 
 - (void)processResponse:(BNCServerResponse *)response error:(NSError *)error {
@@ -26,13 +28,14 @@
         return;
     }
 
-    [BNCPreferenceHelper setSessionID:response.data[@"session_id"]];
-    [BNCPreferenceHelper setIdentityID:response.data[@"identity_id"]];
-    [BNCPreferenceHelper setUserURL:response.data[@"link"]];
-    [BNCPreferenceHelper setUserIdentity:nil];
-    [BNCPreferenceHelper setInstallParams:nil];
-    [BNCPreferenceHelper setSessionParams:nil];
-    [BNCPreferenceHelper clearUserCreditsAndCounts];
+    BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper preferenceHelper];
+    preferenceHelper.sessionID = response.data[@"session_id"];
+    preferenceHelper.identityID = response.data[@"identity_id"];
+    preferenceHelper.userUrl = response.data[@"link"];
+    preferenceHelper.userIdentity = nil;
+    preferenceHelper.installParams = nil;
+    preferenceHelper.sessionParams = nil;
+    [preferenceHelper clearUserCreditsAndCounts];
 }
 
 @end

--- a/Branch-SDK/Branch-SDK/BranchRedeemRewardsRequest.m
+++ b/Branch-SDK/Branch-SDK/BranchRedeemRewardsRequest.m
@@ -30,15 +30,16 @@
 }
 
 - (void)makeRequest:(BNCServerInterface *)serverInterface key:(NSString *)key callback:(BNCServerCallback)callback {
+    BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper preferenceHelper];
     NSDictionary *params = @{
         @"bucket": self.bucket,
         @"amount": @(self.amount),
-        @"device_fingerprint_id": [BNCPreferenceHelper getDeviceFingerprintID],
-        @"identity_id": [BNCPreferenceHelper getIdentityID],
-        @"session_id": [BNCPreferenceHelper getSessionID]
+        @"device_fingerprint_id": preferenceHelper.deviceFingerprintID,
+        @"identity_id": preferenceHelper.identityID,
+        @"session_id": preferenceHelper.sessionID
     };
 
-    [serverInterface postRequest:params url:[BNCPreferenceHelper getAPIURL:@"redeem"] key:key callback:callback];
+    [serverInterface postRequest:params url:[preferenceHelper getAPIURL:@"redeem"] key:key callback:callback];
 }
 
 - (void)processResponse:(BNCServerResponse *)response error:(NSError *)error {
@@ -50,9 +51,10 @@
     }
     
     // Update local balance
-    NSInteger currentAvailableCredits = [BNCPreferenceHelper getCreditCountForBucket:self.bucket];
+    BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper preferenceHelper];
+    NSInteger currentAvailableCredits = [preferenceHelper getCreditCountForBucket:self.bucket];
     NSInteger updatedBalance = currentAvailableCredits - self.amount;
-    [BNCPreferenceHelper setCreditCount:updatedBalance forBucket:self.bucket];
+    [preferenceHelper setCreditCount:updatedBalance forBucket:self.bucket];
     
     if (self.callback) {
         self.callback(YES, nil);

--- a/Branch-SDK/Branch-SDK/BranchSetIdentityRequest.m
+++ b/Branch-SDK/Branch-SDK/BranchSetIdentityRequest.m
@@ -31,14 +31,15 @@
 }
 
 - (void)makeRequest:(BNCServerInterface *)serverInterface key:(NSString *)key callback:(BNCServerCallback)callback {
+    BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper preferenceHelper];
     NSDictionary *params = @{
         @"identity": self.userId,
-        @"device_fingerprint_id": [BNCPreferenceHelper getDeviceFingerprintID],
-        @"session_id": [BNCPreferenceHelper getSessionID],
-        @"identity_id": [BNCPreferenceHelper getIdentityID]
+        @"device_fingerprint_id": preferenceHelper.deviceFingerprintID,
+        @"session_id": preferenceHelper.sessionID,
+        @"identity_id": preferenceHelper.identityID
     };
 
-    [serverInterface postRequest:params url:[BNCPreferenceHelper getAPIURL:@"profile"] key:key callback:callback];
+    [serverInterface postRequest:params url:[preferenceHelper getAPIURL:@"profile"] key:key callback:callback];
 }
 
 - (void)processResponse:(BNCServerResponse *)response error:(NSError *)error {
@@ -51,16 +52,17 @@
         return;
     }
     
-    [BNCPreferenceHelper setIdentityID:response.data[@"identity_id"]];
-    [BNCPreferenceHelper setUserURL:response.data[@"link"]];
-    [BNCPreferenceHelper setUserIdentity:self.userId];
+    BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper preferenceHelper];
+    preferenceHelper.identityID = response.data[@"identity_id"];
+    preferenceHelper.userUrl = response.data[@"link"];
+    preferenceHelper.userIdentity = self.userId;
     
     if (response.data[@"referring_data"]) {
-        [BNCPreferenceHelper setInstallParams:response.data[@"referring_data"]];
+        preferenceHelper.installParams = response.data[@"referring_data"];
     }
     
     if (self.callback && self.shouldCallCallback) {
-        NSString *storedParams = [BNCPreferenceHelper getInstallParams];
+        NSString *storedParams = preferenceHelper.installParams;
         NSDictionary *installParams = [BNCEncodingUtils decodeJsonStringToDictionary:storedParams];
         self.callback(installParams, nil);
     }

--- a/Branch-SDK/Branch-SDK/BranchShortUrlRequest.m
+++ b/Branch-SDK/Branch-SDK/BranchShortUrlRequest.m
@@ -49,18 +49,19 @@
 - (void)makeRequest:(BNCServerInterface *)serverInterface key:(NSString *)key callback:(BNCServerCallback)callback {
     NSMutableDictionary *params = [[NSMutableDictionary alloc] initWithDictionary:self.linkData.data];
 
-    params[@"device_fingerprint_id"] = [BNCPreferenceHelper getDeviceFingerprintID];
-    params[@"identity_id"] = [BNCPreferenceHelper getIdentityID];
-    params[@"session_id"] = [BNCPreferenceHelper getSessionID];
+    BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper preferenceHelper];
+    params[@"device_fingerprint_id"] = preferenceHelper.deviceFingerprintID;
+    params[@"identity_id"] = preferenceHelper.identityID;
+    params[@"session_id"] = preferenceHelper.sessionID;
     
-    [serverInterface postRequest:params url:[BNCPreferenceHelper getAPIURL:@"url"] key:key callback:callback];
+    [serverInterface postRequest:params url:[preferenceHelper getAPIURL:@"url"] key:key callback:callback];
 }
 
 - (void)processResponse:(BNCServerResponse *)response error:(NSError *)error {
     if (error) {
         if (self.callback) {
             NSString *failedUrl = nil;
-            NSString *userUrl = [BNCPreferenceHelper getUserURL];
+            NSString *userUrl = [BNCPreferenceHelper preferenceHelper].userUrl;
             if (!userUrl) {
                 failedUrl = [self createLongUrlForUserUrl:userUrl];
             }

--- a/Branch-SDK/Branch-SDK/BranchShortUrlSyncRequest.m
+++ b/Branch-SDK/Branch-SDK/BranchShortUrlSyncRequest.m
@@ -47,17 +47,18 @@
 - (BNCServerResponse *)makeRequest:(BNCServerInterface *)serverInterface key:(NSString *)key {
     NSMutableDictionary *params = [[NSMutableDictionary alloc] initWithDictionary:self.linkData.data];
     
-    params[@"device_fingerprint_id"] = [BNCPreferenceHelper getDeviceFingerprintID];
-    params[@"identity_id"] = [BNCPreferenceHelper getIdentityID];
-    params[@"session_id"] = [BNCPreferenceHelper getSessionID];
+    BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper preferenceHelper];
+    params[@"device_fingerprint_id"] = preferenceHelper.deviceFingerprintID;
+    params[@"identity_id"] = preferenceHelper.identityID;
+    params[@"session_id"] = preferenceHelper.sessionID;
 
-    return [serverInterface postRequest:params url:[BNCPreferenceHelper getAPIURL:@"url"] key:key log:YES];
+    return [serverInterface postRequest:params url:[preferenceHelper getAPIURL:@"url"] key:key log:YES];
 }
 
 - (NSString *)processResponse:(BNCServerResponse *)response {
     if (![response.statusCode isEqualToNumber:@200]) {
         NSString *failedUrl = nil;
-        NSString *userUrl = [BNCPreferenceHelper getUserURL];
+        NSString *userUrl = [BNCPreferenceHelper preferenceHelper].userUrl;
         if (!userUrl) {
             failedUrl = [self createLongUrlForUserUrl:userUrl];
         }

--- a/Branch-SDK/Branch-SDK/BranchUpdateAppListRequest.m
+++ b/Branch-SDK/Branch-SDK/BranchUpdateAppListRequest.m
@@ -29,12 +29,12 @@
 
 - (void)makeRequest:(BNCServerInterface *)serverInterface key:(NSString *)key callback:(BNCServerCallback)callback {
     NSDictionary *params = @{
-        @"device_fingerprint_id": [BNCPreferenceHelper getDeviceFingerprintID],
+        @"device_fingerprint_id": [BNCPreferenceHelper preferenceHelper].deviceFingerprintID,
         @"os": [BNCSystemObserver getOS],
         @"apps_data": self.appList
     };
 
-    [serverInterface postRequest:params url:[BNCPreferenceHelper getAPIURL:@"applist"] key:key callback:callback];
+    [serverInterface postRequest:params url:[[BNCPreferenceHelper preferenceHelper] getAPIURL:@"applist"] key:key callback:callback];
 }
 
 - (void)processResponse:(BNCServerResponse *)response error:(NSError *)error {
@@ -42,7 +42,7 @@
         return;
     }
     
-    [BNCPreferenceHelper setAppListCheckDone];
+    [[BNCPreferenceHelper preferenceHelper] setAppListCheckDone];
 }
 
 #pragma mark - NSCoding methods

--- a/Branch-SDK/Branch-SDK/BranchUserCompletedActionRequest.m
+++ b/Branch-SDK/Branch-SDK/BranchUserCompletedActionRequest.m
@@ -30,16 +30,17 @@
 - (void)makeRequest:(BNCServerInterface *)serverInterface key:(NSString *)key callback:(BNCServerCallback)callback {
     NSMutableDictionary *params = [[NSMutableDictionary alloc] init];
     
+    BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper preferenceHelper];
     params[@"event"] = self.action;
-    params[@"device_fingerprint_id"] = [BNCPreferenceHelper getDeviceFingerprintID];
-    params[@"identity_id"] = [BNCPreferenceHelper getIdentityID];
-    params[@"session_id"] = [BNCPreferenceHelper getSessionID];
+    params[@"device_fingerprint_id"] = preferenceHelper.deviceFingerprintID;
+    params[@"identity_id"] = preferenceHelper.identityID;
+    params[@"session_id"] = preferenceHelper.sessionID;
     
     if (self.state) {
         params[@"metadata"] = self.state;
     }
 
-    [serverInterface postRequest:params url:[BNCPreferenceHelper getAPIURL:@"event"] key:key callback:callback];
+    [serverInterface postRequest:params url:[preferenceHelper getAPIURL:@"event"] key:key callback:callback];
 }
 
 - (void)processResponse:(BNCServerResponse *)response error:(NSError *)error {

--- a/Branch-SDK/Branch-SDK/BranchValidatePromoCodeRequest.m
+++ b/Branch-SDK/Branch-SDK/BranchValidatePromoCodeRequest.m
@@ -31,14 +31,15 @@
 }
 
 - (void)makeRequest:(BNCServerInterface *)serverInterface key:(NSString *)key callback:(BNCServerCallback)callback {
+    BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper preferenceHelper];
     NSDictionary *params = @{
-        @"identity_id": [BNCPreferenceHelper getIdentityID],
-        @"device_fingerprint_id": [BNCPreferenceHelper getDeviceFingerprintID],
-        @"session_id": [BNCPreferenceHelper getSessionID]
+        @"identity_id": preferenceHelper.identityID,
+        @"device_fingerprint_id": preferenceHelper.deviceFingerprintID,
+        @"session_id": preferenceHelper.sessionID
     };
     
     NSString *endpoint = self.useOld ? @"referralcode/" : @"promo-code/";
-    NSString *url = [[BNCPreferenceHelper getAPIURL:endpoint] stringByAppendingString:self.code];
+    NSString *url = [[preferenceHelper getAPIURL:endpoint] stringByAppendingString:self.code];
     [serverInterface postRequest:params url:url key:key callback:callback];
 }
 

--- a/Branch-TestBed/Branch-SDK Functionality Tests/BNCPreferenceHelperTests.m
+++ b/Branch-TestBed/Branch-SDK Functionality Tests/BNCPreferenceHelperTests.m
@@ -27,23 +27,15 @@
 }
 
 - (void)testPreferenceSets {
-    // Save original values
-    NSInteger retryCount = [BNCPreferenceHelper getRetryCount];
-    NSInteger retryInterval = [BNCPreferenceHelper getRetryInterval];
-    NSInteger timeout = [BNCPreferenceHelper getTimeout];
+    BNCPreferenceHelper *prefHelper = [[BNCPreferenceHelper alloc] init];
     
-    [BNCPreferenceHelper setRetryCount:NSIntegerMax];
-    [BNCPreferenceHelper setRetryInterval:NSIntegerMax];
-    [BNCPreferenceHelper setTimeout:NSIntegerMax];
+    prefHelper.retryCount = NSIntegerMax;
+    prefHelper.retryInterval = NSIntegerMax;
+    prefHelper.timeout = NSIntegerMax;
     
-    XCTAssertEqual([BNCPreferenceHelper getRetryCount], NSIntegerMax);
-    XCTAssertEqual([BNCPreferenceHelper getRetryInterval], NSIntegerMax);
-    XCTAssertEqual([BNCPreferenceHelper getTimeout], NSIntegerMax);
-    
-    // Restore
-    [BNCPreferenceHelper setRetryCount:retryCount];
-    [BNCPreferenceHelper setRetryInterval:retryInterval];
-    [BNCPreferenceHelper setTimeout:timeout];
+    XCTAssertEqual(prefHelper.retryCount, NSIntegerMax);
+    XCTAssertEqual(prefHelper.retryInterval, NSIntegerMax);
+    XCTAssertEqual(prefHelper.timeout, NSIntegerMax);
 }
 
 @end

--- a/Branch-TestBed/Branch-SDK Functionality Tests/BNCPreferenceHelperTests.m
+++ b/Branch-TestBed/Branch-SDK Functionality Tests/BNCPreferenceHelperTests.m
@@ -7,7 +7,6 @@
 //
 
 #import <XCTest/XCTest.h>
-#import <Nocilla/Nocilla.h>
 #import "BNCPreferenceHelper.h"
 #import "BNCEncodingUtils.h"
 
@@ -16,28 +15,6 @@
 @end
 
 @implementation BNCPreferenceHelperTests
-
-+ (void)setUp {
-    [super setUp];
-
-    [[LSNocilla sharedInstance] start];
-    [BNCPreferenceHelper setBranchKey:@"foo"];
-    [BNCPreferenceHelper setDeviceFingerprintID:@"foo"];
-}
-
-+ (void)tearDown {
-    [[LSNocilla sharedInstance] stop];
-    
-    [BNCPreferenceHelper clearDebug];
-
-    [super tearDown];
-}
-
-- (void)tearDown {
-    [[LSNocilla sharedInstance] clearStubs];
-
-    [super tearDown];
-}
 
 #pragma mark - Default storage tests
 - (void)testPreferenceDefaults {

--- a/Branch-TestBed/Branch-SDK Functionality Tests/BNCServerInterfaceTests.m
+++ b/Branch-TestBed/Branch-SDK Functionality Tests/BNCServerInterfaceTests.m
@@ -15,28 +15,9 @@ typedef void (^UrlConnectionCallback)(NSURLResponse *, NSData *, NSError *);
 
 @interface BNCServerInterfaceTests : XCTestCase
 
-@property (assign, nonatomic) NSInteger originalRetryInterval;
-@property (assign, nonatomic) NSInteger originalRetryCount;
-
 @end
 
 @implementation BNCServerInterfaceTests
-
-- (void)setUp {
-    [super setUp];
-
-    self.originalRetryInterval = [BNCPreferenceHelper getRetryInterval];
-    self.originalRetryCount = [BNCPreferenceHelper getRetryCount];
-
-    [BNCPreferenceHelper setRetryInterval:0]; // turn down sleep time
-}
-
-- (void)tearDown {
-    [BNCPreferenceHelper setRetryInterval:self.originalRetryInterval]; // set values back to original
-    [BNCPreferenceHelper setRetryCount:self.originalRetryCount];
-
-    [super tearDown];
-}
 
 
 #pragma mark - Key tests
@@ -76,10 +57,11 @@ typedef void (^UrlConnectionCallback)(NSURLResponse *, NSData *, NSError *);
 
 - (void)testGetRequestAsyncRetriesWhenAppropriate {
     BNCServerInterface *serverInterface = [[BNCServerInterface alloc] init];
+    serverInterface.preferenceHelper = [[BNCPreferenceHelper alloc] init];
     id urlConnectionMock = OCMClassMock([NSURLConnection class]);
     
     // Specify retry count as 3
-    [BNCPreferenceHelper setRetryCount:3];
+    serverInterface.preferenceHelper.retryCount = 3;
 
     // 3 retries means 4 total requests
     [self expectSendAsyncRequestForBranchError:urlConnectionMock times:4];
@@ -99,10 +81,11 @@ typedef void (^UrlConnectionCallback)(NSURLResponse *, NSData *, NSError *);
 
 - (void)testGetRequestAsyncRetriesWhenInappropriateResponse {
     BNCServerInterface *serverInterface = [[BNCServerInterface alloc] init];
+    serverInterface.preferenceHelper = [[BNCPreferenceHelper alloc] init];
     id urlConnectionMock = OCMClassMock([NSURLConnection class]);
 
     // Specify retry count as 3
-    [BNCPreferenceHelper setRetryCount:3];
+    serverInterface.preferenceHelper.retryCount = 3;
 
     // Should be no retries, just a single request
     [self expectSendAsyncRequestForSuccessfulRequest:urlConnectionMock];
@@ -120,10 +103,11 @@ typedef void (^UrlConnectionCallback)(NSURLResponse *, NSData *, NSError *);
 
 - (void)testGetRequestAsyncRetriesWhenInappropriateRetryCount {
     BNCServerInterface *serverInterface = [[BNCServerInterface alloc] init];
+    serverInterface.preferenceHelper = [[BNCPreferenceHelper alloc] init];
     id urlConnectionMock = OCMClassMock([NSURLConnection class]);
     
     // Specify retry count as 0
-    [BNCPreferenceHelper setRetryCount:0];
+    serverInterface.preferenceHelper.retryCount = 0;
     
     // 0 retries means 1 total requests
     [self expectSendAsyncRequestForBranchError:urlConnectionMock times:1];
@@ -141,10 +125,11 @@ typedef void (^UrlConnectionCallback)(NSURLResponse *, NSData *, NSError *);
 
 - (void)testPostRequestAsyncRetriesWhenAppropriate {
     BNCServerInterface *serverInterface = [[BNCServerInterface alloc] init];
+    serverInterface.preferenceHelper = [[BNCPreferenceHelper alloc] init];
     id urlConnectionMock = OCMClassMock([NSURLConnection class]);
     
     // Specify retry count as 3
-    [BNCPreferenceHelper setRetryCount:3];
+    serverInterface.preferenceHelper.retryCount = 3;
     
     // 3 retries means 4 total requests
     [self expectSendAsyncRequestForBranchError:urlConnectionMock times:4];
@@ -162,10 +147,11 @@ typedef void (^UrlConnectionCallback)(NSURLResponse *, NSData *, NSError *);
 
 - (void)testPostRequestAsyncRetriesWhenInappropriateResponse {
     BNCServerInterface *serverInterface = [[BNCServerInterface alloc] init];
+    serverInterface.preferenceHelper = [[BNCPreferenceHelper alloc] init];
     id urlConnectionMock = OCMClassMock([NSURLConnection class]);
     
     // Specify retry count as 3
-    [BNCPreferenceHelper setRetryCount:3];
+    serverInterface.preferenceHelper.retryCount = 3;
     
     // Should be no retries, just a single request
     [self expectSendAsyncRequestForSuccessfulRequest:urlConnectionMock];
@@ -183,10 +169,11 @@ typedef void (^UrlConnectionCallback)(NSURLResponse *, NSData *, NSError *);
 
 - (void)testPostRequestAsyncRetriesWhenInappropriateRetryCount {
     BNCServerInterface *serverInterface = [[BNCServerInterface alloc] init];
+    serverInterface.preferenceHelper = [[BNCPreferenceHelper alloc] init];
     id urlConnectionMock = OCMClassMock([NSURLConnection class]);
     
     // Specify retry count as 0
-    [BNCPreferenceHelper setRetryCount:0];
+    serverInterface.preferenceHelper.retryCount = 0;
     
     // 0 retries means 1 total requests
     [self expectSendAsyncRequestForBranchError:urlConnectionMock times:1];

--- a/Branch-TestBed/Branch-SDK Functionality Tests/BNCSystemObserverTests.m
+++ b/Branch-TestBed/Branch-SDK Functionality Tests/BNCSystemObserverTests.m
@@ -75,8 +75,7 @@
 
 - (void)testGetUpdateStateWithEqualStoredAndCurrentVersion {
     NSString *version = @"1";
-    id preferenceHelperMock = [OCMockObject mockForClass:[BNCPreferenceHelper class]];
-    [[[preferenceHelperMock stub] andReturn:version] getAppVersion];
+    [BNCPreferenceHelper preferenceHelper].appVersion = version;
     
     id bundleMock = OCMClassMock([NSBundle class]);
     [[[bundleMock stub] andReturn:bundleMock] mainBundle];
@@ -90,8 +89,7 @@
 - (void)testGetUpdateStateWithNonEqualStoredAndCurrentVersion {
     NSString *currentVersion = @"2";
     NSString *storedVersion = @"1";
-    id preferenceHelperMock = [OCMockObject mockForClass:[BNCPreferenceHelper class]];
-    [[[preferenceHelperMock stub] andReturn:storedVersion] getAppVersion];
+    [BNCPreferenceHelper preferenceHelper].appVersion = storedVersion;
     
     id bundleMock = OCMClassMock([NSBundle class]);
     [[[bundleMock stub] andReturn:bundleMock] mainBundle];
@@ -117,8 +115,7 @@
 }
 
 - (void)stubNilValuesForStoredAndCurrentVersions {
-    id preferenceHelperMock = [OCMockObject mockForClass:[BNCPreferenceHelper class]];
-    [[[preferenceHelperMock stub] andReturn:nil] getAppVersion];
+    [BNCPreferenceHelper preferenceHelper].appVersion = nil;
 
     id bundleMock = OCMClassMock([NSBundle class]);
     [[[bundleMock stub] andReturn:nil] mainBundle];

--- a/Branch-TestBed/Branch-SDK Functionality Tests/BranchConnectDebugRequestTests.m
+++ b/Branch-TestBed/Branch-SDK Functionality Tests/BranchConnectDebugRequestTests.m
@@ -24,7 +24,7 @@
     
     [request processResponse:response error:nil];
     
-    XCTAssertTrue([BNCPreferenceHelper isConnectedToRemoteDebug]);
+    XCTAssertTrue([[BNCPreferenceHelper preferenceHelper] isConnectedToRemoteDebug]);
 }
 
 - (void)testDebuggerConnectFailure {
@@ -35,7 +35,7 @@
     
     [request processResponse:response error:connectError];
     
-    XCTAssertFalse([BNCPreferenceHelper isConnectedToRemoteDebug]);
+    XCTAssertFalse([[BNCPreferenceHelper preferenceHelper] isConnectedToRemoteDebug]);
 }
 
 @end

--- a/Branch-TestBed/Branch-SDK Functionality Tests/BranchNetworkScenarioTests.m
+++ b/Branch-TestBed/Branch-SDK Functionality Tests/BranchNetworkScenarioTests.m
@@ -23,14 +23,6 @@
 
 @implementation BranchNetworkScenarioTests
 
-- (void)setUp {
-    [super setUp];
-
-    // Fake branch key
-    id preferenceHelperMock = OCMClassMock([BNCPreferenceHelper class]);
-    [[[preferenceHelperMock stub] andReturn:@"foo"] getBranchKey:YES];
-}
-
 #pragma mark - Scenario 1
 
 // Connection starts good -- InitSession completes
@@ -42,7 +34,7 @@
 - (void)testScenario1 {
     id serverInterfaceMock = OCMClassMock([BNCServerInterface class]);
     
-    Branch *branch = [[Branch alloc] initWithInterface:serverInterfaceMock queue:[[BNCServerRequestQueue alloc] init] cache:[[BNCLinkCache alloc] init] key:@"key_live"];
+    Branch *branch = [[Branch alloc] initWithInterface:serverInterfaceMock queue:[[BNCServerRequestQueue alloc] init] cache:[[BNCLinkCache alloc] init] preferenceHelper:[BNCPreferenceHelper preferenceHelper] key:@"key_live"];
     [branch setAppListCheckEnabled:NO];
 
     XCTestExpectation *scenario1Expectation1 = [self expectationWithDescription:@"Scenario1 Expectation1"];
@@ -85,7 +77,7 @@
 - (void)testScenario2 {
     id serverInterfaceMock = OCMClassMock([BNCServerInterface class]);
     
-    Branch *branch = [[Branch alloc] initWithInterface:serverInterfaceMock queue:[[BNCServerRequestQueue alloc] init] cache:[[BNCLinkCache alloc] init] key:@"key_foo"];
+    Branch *branch = [[Branch alloc] initWithInterface:serverInterfaceMock queue:[[BNCServerRequestQueue alloc] init] cache:[[BNCLinkCache alloc] init] preferenceHelper:[BNCPreferenceHelper preferenceHelper] key:@"key_foo"];
     [branch setAppListCheckEnabled:NO];
 
     XCTestExpectation *scenario2Expectation1 = [self expectationWithDescription:@"Scenario2 Expectation1"];
@@ -135,7 +127,7 @@
 - (void)testScenario3 {
     id serverInterfaceMock = OCMClassMock([BNCServerInterface class]);
     
-    Branch *branch = [[Branch alloc] initWithInterface:serverInterfaceMock queue:[[BNCServerRequestQueue alloc] init] cache:[[BNCLinkCache alloc] init] key:@"key_foo"];
+    Branch *branch = [[Branch alloc] initWithInterface:serverInterfaceMock queue:[[BNCServerRequestQueue alloc] init] cache:[[BNCLinkCache alloc] init] preferenceHelper:[BNCPreferenceHelper preferenceHelper] key:@"key_foo"];
     [branch setAppListCheckEnabled:NO];
 
     XCTestExpectation *scenario3Expectation1 = [self expectationWithDescription:@"Scenario3 Expectation1"];
@@ -178,7 +170,7 @@
 - (void)testScenario4 {
     id serverInterfaceMock = OCMClassMock([BNCServerInterface class]);
     
-    Branch *branch = [[Branch alloc] initWithInterface:serverInterfaceMock queue:[[BNCServerRequestQueue alloc] init] cache:[[BNCLinkCache alloc] init] key:@"key_foo"];
+    Branch *branch = [[Branch alloc] initWithInterface:serverInterfaceMock queue:[[BNCServerRequestQueue alloc] init] cache:[[BNCLinkCache alloc] init] preferenceHelper:[BNCPreferenceHelper preferenceHelper] key:@"key_foo"];
     [branch setAppListCheckEnabled:NO];
     
     XCTestExpectation *scenario4Expectation1 = [self expectationWithDescription:@"Scenario4 Expectation1"];
@@ -228,7 +220,7 @@
 - (void)testScenario5 {
     id serverInterfaceMock = OCMClassMock([BNCServerInterface class]);
     
-    Branch *branch = [[Branch alloc] initWithInterface:serverInterfaceMock queue:[[BNCServerRequestQueue alloc] init] cache:[[BNCLinkCache alloc] init] key:@"key_live"];
+    Branch *branch = [[Branch alloc] initWithInterface:serverInterfaceMock queue:[[BNCServerRequestQueue alloc] init] cache:[[BNCLinkCache alloc] init] preferenceHelper:[BNCPreferenceHelper preferenceHelper] key:@"key_live"];
     [branch setAppListCheckEnabled:NO];
     
     XCTestExpectation *scenario5Expectation1 = [self expectationWithDescription:@"Scenario5 Expectation1"];
@@ -259,7 +251,7 @@
 - (void)testScenario6 {
     id serverInterfaceMock = OCMClassMock([BNCServerInterface class]);
     
-    Branch *branch = [[Branch alloc] initWithInterface:serverInterfaceMock queue:[[BNCServerRequestQueue alloc] init] cache:[[BNCLinkCache alloc] init] key:@"key_live"];
+    Branch *branch = [[Branch alloc] initWithInterface:serverInterfaceMock queue:[[BNCServerRequestQueue alloc] init] cache:[[BNCLinkCache alloc] init] preferenceHelper:[BNCPreferenceHelper preferenceHelper] key:@"key_live"];
     [branch setAppListCheckEnabled:NO];
     
     XCTestExpectation *scenario6Expectation1 = [self expectationWithDescription:@"Scenario5 Expectation1"];
@@ -330,7 +322,7 @@
     [[[queueMock expect] andReturnValue:@YES] containsInstallOrOpen];
     [(BNCServerRequestQueue *)[[queueMock stub] andReturnValue:@1] size];
     
-    Branch *branch = [[Branch alloc] initWithInterface:serverInterfaceMock queue:queueMock cache:nil key:@"key_live"];
+    Branch *branch = [[Branch alloc] initWithInterface:serverInterfaceMock queue:queueMock cache:nil preferenceHelper:nil key:@"key_live"];
     
     __block NSInteger initCallbackCount = 0;
     [branch initSessionAndRegisterDeepLinkHandler:^(NSDictionary *params, NSError *error) {
@@ -395,7 +387,8 @@
         badRequestCallback(nil, [NSError errorWithDomain:NSURLErrorDomain code:-1004 userInfo:nil]);
     };
     
-    NSString *url = [[BNCPreferenceHelper getAPIURL:@"referrals/"] stringByAppendingString:[BNCPreferenceHelper getIdentityID]];
+    BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper preferenceHelper];
+    NSString *url = [[preferenceHelper getAPIURL:@"referrals/"] stringByAppendingString:preferenceHelper.identityID];
     [[[serverInterfaceMock expect] andDo:badRequestInvocation] getRequest:[OCMArg any] url:url key:[OCMArg any] callback:badRequestCheckBlock];
     
     [branch loadActionCountsWithCallback:^(BOOL changed, NSError *error) {
@@ -412,7 +405,8 @@
     }];
     
     // Only one request should make it to the server
-    NSString *url = [[BNCPreferenceHelper getAPIURL:@"referrals/"] stringByAppendingString:[BNCPreferenceHelper getIdentityID]];
+    BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper preferenceHelper];
+    NSString *url = [[preferenceHelper getAPIURL:@"referrals/"] stringByAppendingString:preferenceHelper.identityID];
     [[serverInterfaceMock expect] getRequest:[OCMArg any] url:url key:[OCMArg any] callback:badRequestCheckBlock];
     [[serverInterfaceMock reject] getRequest:[OCMArg any] url:url key:[OCMArg any] callback:[OCMArg any]];
     
@@ -444,7 +438,8 @@
     }];
     
     // Only one request should make it to the server
-    NSString *url = [[BNCPreferenceHelper getAPIURL:@"referrals/"] stringByAppendingString:[BNCPreferenceHelper getIdentityID]];
+    BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper preferenceHelper];
+    NSString *url = [[preferenceHelper getAPIURL:@"referrals/"] stringByAppendingString:preferenceHelper.identityID];
     [[serverInterfaceMock expect] getRequest:[OCMArg any] url:url key:[OCMArg any] callback:badRequestCheckBlock];
     [[serverInterfaceMock expect] getRequest:[OCMArg any] url:url key:[OCMArg any] callback:goodRequestCheckBlock];
     
@@ -477,7 +472,8 @@
         goodRequestCallback(goodResponse, nil);
     };
     
-    NSString *url = [[BNCPreferenceHelper getAPIURL:@"referrals/"] stringByAppendingString:[BNCPreferenceHelper getIdentityID]];
+    BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper preferenceHelper];
+    NSString *url = [[preferenceHelper getAPIURL:@"referrals/"] stringByAppendingString:preferenceHelper.identityID];
     [[[serverInterfaceMock expect] andDo:goodRequestInvocation] getRequest:[OCMArg any] url:url key:[OCMArg any] callback:goodRequestCheckBlock];
     
     [branch loadActionCountsWithCallback:^(BOOL changed, NSError *error) {

--- a/Branch-TestBed/Branch-SDK Functionality Tests/Branch_SDK_Functionality_Tests.m
+++ b/Branch-TestBed/Branch-SDK Functionality Tests/Branch_SDK_Functionality_Tests.m
@@ -40,8 +40,11 @@ NSInteger const  TEST_CREDITS = 30;
 
 - (void)test00OpenOrInstall {
     id serverInterfaceMock = OCMClassMock([BNCServerInterface class]);
+
+    BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper preferenceHelper];
+    preferenceHelper.branchKey = @"foo";
     
-    Branch *branch = [[Branch alloc] initWithInterface:serverInterfaceMock queue:[[BNCServerRequestQueue alloc] init] cache:[[BNCLinkCache alloc] init] key:@"foo"];
+    Branch *branch = [[Branch alloc] initWithInterface:serverInterfaceMock queue:[[BNCServerRequestQueue alloc] init] cache:[[BNCLinkCache alloc] init] preferenceHelper:preferenceHelper key:@"foo"];
     [branch setAppListCheckEnabled:NO];
     
     BNCServerResponse *openInstallResponse = [[BNCServerResponse alloc] init];
@@ -67,16 +70,11 @@ NSInteger const  TEST_CREDITS = 30;
         return [url rangeOfString:@"open"].location != NSNotFound || [url rangeOfString:@"install"].location != NSNotFound;
     }];
     [[[serverInterfaceMock expect] andDo:openOrInstallInvocation] postRequest:[OCMArg any] url:openOrInstallUrlCheckBlock key:[OCMArg any] callback:openOrInstallCallbackCheckBlock];
-
-    // Fake branch key
-    id preferenceHelperMock = OCMClassMock([BNCPreferenceHelper class]);
-    [[[preferenceHelperMock stub] andReturn:@"foo"] getBranchKey:YES];
     
     XCTestExpectation *openExpectation = [self expectationWithDescription:@"Test open"];
     [branch initSessionAndRegisterDeepLinkHandler:^(NSDictionary *params, NSError *error) {
         XCTAssertNil(error);
-        XCTAssertNotNil([BNCPreferenceHelper getSessionID]);
-        XCTAssertEqualObjects([BNCPreferenceHelper getSessionID], TEST_SESSION_ID);
+        XCTAssertEqualObjects(preferenceHelper.sessionID, TEST_SESSION_ID);
         
         [openExpectation fulfill];
     }];
@@ -88,16 +86,17 @@ NSInteger const  TEST_CREDITS = 30;
     id serverInterfaceMock = OCMClassMock([BNCServerInterface class]);
     [self setupDefaultStubsForServerInterfaceMock:serverInterfaceMock];
     
-    Branch *branch = [[Branch alloc] initWithInterface:serverInterfaceMock queue:[[BNCServerRequestQueue alloc] init] cache:[[BNCLinkCache alloc] init] key:@"foo"];
+    BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper preferenceHelper];
+    Branch *branch = [[Branch alloc] initWithInterface:serverInterfaceMock queue:[[BNCServerRequestQueue alloc] init] cache:[[BNCLinkCache alloc] init] preferenceHelper:preferenceHelper key:@"foo"];
     [branch setAppListCheckEnabled:NO];
     
     // mock logout synchronously
-    [BNCPreferenceHelper setIdentityID:@"98274447349252681"];
-    [BNCPreferenceHelper setUserURL:@"https://bnc.lt/i/3R7_PIk-77"];
-    [BNCPreferenceHelper setUserIdentity:nil];
-    [BNCPreferenceHelper setInstallParams:nil];
-    [BNCPreferenceHelper setSessionParams:nil];
-    [BNCPreferenceHelper clearUserCreditsAndCounts];
+    preferenceHelper.identityID = @"98274447349252681";
+    preferenceHelper.userUrl = @"https://bnc.lt/i/3R7_PIk-77";
+    preferenceHelper.userIdentity = nil;
+    preferenceHelper.installParams = nil;
+    preferenceHelper.sessionParams = nil;
+    [preferenceHelper clearUserCreditsAndCounts];
     
     BNCServerResponse *setIdentityResponse = [[BNCServerResponse alloc] init];
     setIdentityResponse.data = @{
@@ -111,7 +110,7 @@ NSInteger const  TEST_CREDITS = 30;
     __block BNCServerCallback setIdentityCallback;
     [[[serverInterfaceMock expect] andDo:^(NSInvocation *invocation) {
         setIdentityCallback(setIdentityResponse, nil);
-    }] postRequest:[OCMArg any] url:[BNCPreferenceHelper getAPIURL:@"profile"] key:[OCMArg any] callback:[OCMArg checkWithBlock:^BOOL(BNCServerCallback callback) {
+    }] postRequest:[OCMArg any] url:[preferenceHelper getAPIURL:@"profile"] key:[OCMArg any] callback:[OCMArg checkWithBlock:^BOOL(BNCServerCallback callback) {
         setIdentityCallback = callback;
         return YES;
     }]];
@@ -122,7 +121,7 @@ NSInteger const  TEST_CREDITS = 30;
         XCTAssertNil(error);
         XCTAssertNotNil(params);
         
-        XCTAssertEqualObjects([BNCPreferenceHelper getIdentityID], @"98687515069776101");
+        XCTAssertEqualObjects(preferenceHelper.identityID, @"98687515069776101");
         NSDictionary *installParams = [nonRetainedBranch getFirstReferringParams];
         
         XCTAssertEqualObjects(installParams[@"$og_title"], @"Kindred"); //TODO: equal to params?
@@ -140,7 +139,8 @@ NSInteger const  TEST_CREDITS = 30;
     id serverInterfaceMock = OCMClassMock([BNCServerInterface class]);
     [self setupDefaultStubsForServerInterfaceMock:serverInterfaceMock];
     
-    Branch *branch = [[Branch alloc] initWithInterface:serverInterfaceMock queue:[[BNCServerRequestQueue alloc] init] cache:[[BNCLinkCache alloc] init] key:@"key_foo"];
+    BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper preferenceHelper];
+    Branch *branch = [[Branch alloc] initWithInterface:serverInterfaceMock queue:[[BNCServerRequestQueue alloc] init] cache:[[BNCLinkCache alloc] init] preferenceHelper:preferenceHelper key:@"key_foo"];
     [branch setAppListCheckEnabled:NO];
 
     BNCServerResponse *fbLinkResponse = [[BNCServerResponse alloc] init];
@@ -154,18 +154,18 @@ NSInteger const  TEST_CREDITS = 30;
     __block BNCServerCallback fbCallback;
     [[[serverInterfaceMock expect] andDo:^(NSInvocation *invocation) {
         fbCallback(fbLinkResponse, nil);
-    }] postRequest:[OCMArg any] url:[BNCPreferenceHelper getAPIURL:@"url"] key:[OCMArg any] callback:[OCMArg checkWithBlock:^BOOL(BNCServerCallback callback) {
+    }] postRequest:[OCMArg any] url:[preferenceHelper getAPIURL:@"url"] key:[OCMArg any] callback:[OCMArg checkWithBlock:^BOOL(BNCServerCallback callback) {
         fbCallback = callback;
         return YES;
     }]];
     
     [[serverInterfaceMock reject] postRequest:[OCMArg checkWithBlock:^BOOL(NSDictionary *params) {
         return [params[@"channel"] isEqualToString:@"facebook"];
-    }] url:[BNCPreferenceHelper getAPIURL:@"url"] key:[OCMArg any] log:YES];
+    }] url:[preferenceHelper getAPIURL:@"url"] key:[OCMArg any] log:YES];
     
     [[[serverInterfaceMock expect] andReturn:twLinkResponse] postRequest:[OCMArg checkWithBlock:^BOOL(NSDictionary *params) {
         return [params[@"channel"] isEqualToString:@"twitter"];
-    }] url:[BNCPreferenceHelper getAPIURL:@"url"] key:[OCMArg any] log:YES];
+    }] url:[preferenceHelper getAPIURL:@"url"] key:[OCMArg any] log:YES];
     
     XCTestExpectation *getShortURLExpectation = [self expectationWithDescription:@"Test getShortURL"];
     
@@ -199,7 +199,8 @@ NSInteger const  TEST_CREDITS = 30;
     id serverInterfaceMock = OCMClassMock([BNCServerInterface class]);
     [self setupDefaultStubsForServerInterfaceMock:serverInterfaceMock];
     
-    Branch *branch = [[Branch alloc] initWithInterface:serverInterfaceMock queue:[[BNCServerRequestQueue alloc] init] cache:[[BNCLinkCache alloc] init] key:@"key_foo"];
+    BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper preferenceHelper];
+    Branch *branch = [[Branch alloc] initWithInterface:serverInterfaceMock queue:[[BNCServerRequestQueue alloc] init] cache:[[BNCLinkCache alloc] init] preferenceHelper:preferenceHelper key:@"key_foo"];
     [branch setAppListCheckEnabled:NO];
 
     XCTestExpectation *getShortURLExpectation = [self expectationWithDescription:@"Test getShortURL Sync"];
@@ -215,16 +216,16 @@ NSInteger const  TEST_CREDITS = 30;
         // FB should only be called once
         [[[serverInterfaceMock expect] andReturn:fbLinkResponse] postRequest:[OCMArg checkWithBlock:^BOOL(NSDictionary *params) {
             return [params[@"channel"] isEqualToString:@"facebook"];
-        }] url:[BNCPreferenceHelper getAPIURL:@"url"] key:[OCMArg any] log:YES];
+        }] url:[preferenceHelper getAPIURL:@"url"] key:[OCMArg any] log:YES];
         
         [[serverInterfaceMock reject] postRequest:[OCMArg checkWithBlock:^BOOL(NSDictionary *params) {
             return [params[@"channel"] isEqualToString:@"facebook"];
-        }] url:[BNCPreferenceHelper getAPIURL:@"url"] key:[OCMArg any] log:YES];
+        }] url:[preferenceHelper getAPIURL:@"url"] key:[OCMArg any] log:YES];
         
         // TW should be allowed still
         [[[serverInterfaceMock expect] andReturn:twLinkResponse] postRequest:[OCMArg checkWithBlock:^BOOL(NSDictionary *params) {
             return [params[@"channel"] isEqualToString:@"twitter"];
-        }] url:[BNCPreferenceHelper getAPIURL:@"url"] key:[OCMArg any] log:YES];
+        }] url:[preferenceHelper getAPIURL:@"url"] key:[OCMArg any] log:YES];
         
         NSString *url1 = [branch getShortURLWithParams:nil andChannel:@"facebook" andFeature:nil];
         XCTAssertNotNil(url1);
@@ -248,10 +249,11 @@ NSInteger const  TEST_CREDITS = 30;
     id serverInterfaceMock = OCMClassMock([BNCServerInterface class]);
     [self setupDefaultStubsForServerInterfaceMock:serverInterfaceMock];
     
-    Branch *branch = [[Branch alloc] initWithInterface:serverInterfaceMock queue:[[BNCServerRequestQueue alloc] init] cache:[[BNCLinkCache alloc] init] key:@"key_foo"];
+    BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper preferenceHelper];
+    Branch *branch = [[Branch alloc] initWithInterface:serverInterfaceMock queue:[[BNCServerRequestQueue alloc] init] cache:[[BNCLinkCache alloc] init] preferenceHelper:preferenceHelper key:@"key_foo"];
     [branch setAppListCheckEnabled:NO];
 
-    [BNCPreferenceHelper setCreditCount:NSIntegerMax forBucket:@"default"];
+    [preferenceHelper setCreditCount:NSIntegerMax forBucket:@"default"];
     
     BNCServerResponse *loadCreditsResponse = [[BNCServerResponse alloc] init];
     loadCreditsResponse.data = @{ @"default": @(NSIntegerMin) };
@@ -259,7 +261,7 @@ NSInteger const  TEST_CREDITS = 30;
     __block BNCServerCallback loadCreditsCallback;
     [[[serverInterfaceMock expect] andDo:^(NSInvocation *invocation) {
         loadCreditsCallback(loadCreditsResponse, nil);
-    }] getRequest:[OCMArg any] url:[BNCPreferenceHelper getAPIURL:[NSString stringWithFormat:@"%@/%@", @"credits", [BNCPreferenceHelper getIdentityID]]] key:[OCMArg any] callback:[OCMArg checkWithBlock:^BOOL(BNCServerCallback callback) {
+    }] getRequest:[OCMArg any] url:[preferenceHelper getAPIURL:[NSString stringWithFormat:@"%@/%@", @"credits", preferenceHelper.identityID]] key:[OCMArg any] callback:[OCMArg checkWithBlock:^BOOL(BNCServerCallback callback) {
         loadCreditsCallback = callback;
         return YES;
     }]];
@@ -280,10 +282,11 @@ NSInteger const  TEST_CREDITS = 30;
     id serverInterfaceMock = OCMClassMock([BNCServerInterface class]);
     [self setupDefaultStubsForServerInterfaceMock:serverInterfaceMock];
     
-    Branch *branch = [[Branch alloc] initWithInterface:serverInterfaceMock queue:[[BNCServerRequestQueue alloc] init] cache:[[BNCLinkCache alloc] init] key:@"key_foo"];
+    BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper preferenceHelper];
+    Branch *branch = [[Branch alloc] initWithInterface:serverInterfaceMock queue:[[BNCServerRequestQueue alloc] init] cache:[[BNCLinkCache alloc] init] preferenceHelper:preferenceHelper key:@"key_foo"];
     [branch setAppListCheckEnabled:NO];
 
-    [BNCPreferenceHelper setCreditCount:1 forBucket:@"default"];
+    [preferenceHelper setCreditCount:1 forBucket:@"default"];
     
     BNCServerResponse *loadRewardsResponse = [[BNCServerResponse alloc] init];
     loadRewardsResponse.data = @{ @"default": @1 };
@@ -291,7 +294,7 @@ NSInteger const  TEST_CREDITS = 30;
     __block BNCServerCallback loadRewardsCallback;
     [[[serverInterfaceMock expect] andDo:^(NSInvocation *invocation) {
         loadRewardsCallback(loadRewardsResponse, nil);
-    }] getRequest:[OCMArg any] url:[BNCPreferenceHelper getAPIURL:[NSString stringWithFormat:@"%@/%@", @"credits", [BNCPreferenceHelper getIdentityID]]] key:[OCMArg any] callback:[OCMArg checkWithBlock:^BOOL(BNCServerCallback callback) {
+    }] getRequest:[OCMArg any] url:[preferenceHelper getAPIURL:[NSString stringWithFormat:@"%@/%@", @"credits", preferenceHelper.identityID]] key:[OCMArg any] callback:[OCMArg checkWithBlock:^BOOL(BNCServerCallback callback) {
         loadRewardsCallback = callback;
         return YES;
     }]];
@@ -312,10 +315,11 @@ NSInteger const  TEST_CREDITS = 30;
     id serverInterfaceMock = OCMClassMock([BNCServerInterface class]);
     [self setupDefaultStubsForServerInterfaceMock:serverInterfaceMock];
     
-    Branch *branch = [[Branch alloc] initWithInterface:serverInterfaceMock queue:[[BNCServerRequestQueue alloc] init] cache:[[BNCLinkCache alloc] init] key:@"key_foo"];
+    BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper preferenceHelper];
+    Branch *branch = [[Branch alloc] initWithInterface:serverInterfaceMock queue:[[BNCServerRequestQueue alloc] init] cache:[[BNCLinkCache alloc] init] preferenceHelper:preferenceHelper key:@"key_foo"];
     [branch setAppListCheckEnabled:NO];
     
-    [BNCPreferenceHelper setCreditCount:1 forBucket:@"default"];
+    [preferenceHelper setCreditCount:1 forBucket:@"default"];
     
     BNCServerResponse *referralCodeResponse = [[BNCServerResponse alloc] init];
     referralCodeResponse.data = @{
@@ -341,7 +345,7 @@ NSInteger const  TEST_CREDITS = 30;
     __block BNCServerCallback referralCodeCallback;
     [[[serverInterfaceMock expect] andDo:^(NSInvocation *invocation) {
         referralCodeCallback(referralCodeResponse, nil);
-    }] postRequest:[OCMArg any] url:[BNCPreferenceHelper getAPIURL:@"promo-code"] key:[OCMArg any] callback:[OCMArg checkWithBlock:^BOOL(BNCServerCallback callback) {
+    }] postRequest:[OCMArg any] url:[preferenceHelper getAPIURL:@"promo-code"] key:[OCMArg any] callback:[OCMArg checkWithBlock:^BOOL(BNCServerCallback callback) {
         referralCodeCallback = callback;
         return YES;
     }]];
@@ -361,10 +365,11 @@ NSInteger const  TEST_CREDITS = 30;
     id serverInterfaceMock = OCMClassMock([BNCServerInterface class]);
     [self setupDefaultStubsForServerInterfaceMock:serverInterfaceMock];
     
-    Branch *branch = [[Branch alloc] initWithInterface:serverInterfaceMock queue:[[BNCServerRequestQueue alloc] init] cache:[[BNCLinkCache alloc] init] key:@"key_foo"];
+    BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper preferenceHelper];
+    Branch *branch = [[Branch alloc] initWithInterface:serverInterfaceMock queue:[[BNCServerRequestQueue alloc] init] cache:[[BNCLinkCache alloc] init] preferenceHelper:preferenceHelper key:@"key_foo"];
     [branch setAppListCheckEnabled:NO];
     
-    [BNCPreferenceHelper setCreditCount:1 forBucket:@"default"];
+    [preferenceHelper setCreditCount:1 forBucket:@"default"];
     
     BNCServerResponse *referralCodeResponse = [[BNCServerResponse alloc] init];
     referralCodeResponse.data = @{
@@ -390,7 +395,7 @@ NSInteger const  TEST_CREDITS = 30;
     __block BNCServerCallback referralCodeCallback;
     [[[serverInterfaceMock expect] andDo:^(NSInvocation *invocation) {
         referralCodeCallback(referralCodeResponse, nil);
-    }] postRequest:[OCMArg any] url:[BNCPreferenceHelper getAPIURL:@"referralcode"] key:[OCMArg any] callback:[OCMArg checkWithBlock:^BOOL(BNCServerCallback callback) {
+    }] postRequest:[OCMArg any] url:[preferenceHelper getAPIURL:@"referralcode"] key:[OCMArg any] callback:[OCMArg checkWithBlock:^BOOL(BNCServerCallback callback) {
         referralCodeCallback = callback;
         return YES;
     }]];
@@ -413,10 +418,11 @@ NSInteger const  TEST_CREDITS = 30;
     id serverInterfaceMock = OCMClassMock([BNCServerInterface class]);
     [self setupDefaultStubsForServerInterfaceMock:serverInterfaceMock];
     
-    Branch *branch = [[Branch alloc] initWithInterface:serverInterfaceMock queue:[[BNCServerRequestQueue alloc] init] cache:[[BNCLinkCache alloc] init] key:@"key_foo"];
+    BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper preferenceHelper];
+    Branch *branch = [[Branch alloc] initWithInterface:serverInterfaceMock queue:[[BNCServerRequestQueue alloc] init] cache:[[BNCLinkCache alloc] init] preferenceHelper:preferenceHelper key:@"key_foo"];
     [branch setAppListCheckEnabled:NO];
 
-    [BNCPreferenceHelper setCreditCount:1 forBucket:@"default"];
+    [preferenceHelper setCreditCount:1 forBucket:@"default"];
     
     BNCServerResponse *validateCodeResponse = [[BNCServerResponse alloc] init];
     validateCodeResponse.data = @{
@@ -442,7 +448,7 @@ NSInteger const  TEST_CREDITS = 30;
     __block BNCServerCallback validateCodeCallback;
     [[[serverInterfaceMock expect] andDo:^(NSInvocation *invocation) {
         validateCodeCallback(validateCodeResponse, nil);
-    }] postRequest:[OCMArg any] url:[BNCPreferenceHelper getAPIURL:@"promo-code/LMDLDV"] key:[OCMArg any] callback:[OCMArg checkWithBlock:^BOOL(BNCServerCallback callback) {
+    }] postRequest:[OCMArg any] url:[preferenceHelper getAPIURL:@"promo-code/LMDLDV"] key:[OCMArg any] callback:[OCMArg checkWithBlock:^BOOL(BNCServerCallback callback) {
         validateCodeCallback = callback;
         return YES;
     }]];
@@ -468,10 +474,11 @@ NSInteger const  TEST_CREDITS = 30;
     id serverInterfaceMock = OCMClassMock([BNCServerInterface class]);
     [self setupDefaultStubsForServerInterfaceMock:serverInterfaceMock];
     
-    Branch *branch = [[Branch alloc] initWithInterface:serverInterfaceMock queue:[[BNCServerRequestQueue alloc] init] cache:[[BNCLinkCache alloc] init] key:@"key_foo"];
+    BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper preferenceHelper];
+    Branch *branch = [[Branch alloc] initWithInterface:serverInterfaceMock queue:[[BNCServerRequestQueue alloc] init] cache:[[BNCLinkCache alloc] init] preferenceHelper:preferenceHelper key:@"key_foo"];
     [branch setAppListCheckEnabled:NO];
     
-    [BNCPreferenceHelper setCreditCount:1 forBucket:@"default"];
+    [preferenceHelper setCreditCount:1 forBucket:@"default"];
     
     BNCServerResponse *validateCodeResponse = [[BNCServerResponse alloc] init];
     validateCodeResponse.data = @{
@@ -497,7 +504,7 @@ NSInteger const  TEST_CREDITS = 30;
     __block BNCServerCallback validateCodeCallback;
     [[[serverInterfaceMock expect] andDo:^(NSInvocation *invocation) {
         validateCodeCallback(validateCodeResponse, nil);
-    }] postRequest:[OCMArg any] url:[BNCPreferenceHelper getAPIURL:@"referralcode/LMDLDV"] key:[OCMArg any] callback:[OCMArg checkWithBlock:^BOOL(BNCServerCallback callback) {
+    }] postRequest:[OCMArg any] url:[preferenceHelper getAPIURL:@"referralcode/LMDLDV"] key:[OCMArg any] callback:[OCMArg checkWithBlock:^BOOL(BNCServerCallback callback) {
         validateCodeCallback = callback;
         return YES;
     }]];
@@ -526,10 +533,11 @@ NSInteger const  TEST_CREDITS = 30;
     id serverInterfaceMock = OCMClassMock([BNCServerInterface class]);
     [self setupDefaultStubsForServerInterfaceMock:serverInterfaceMock];
     
-    Branch *branch = [[Branch alloc] initWithInterface:serverInterfaceMock queue:[[BNCServerRequestQueue alloc] init] cache:[[BNCLinkCache alloc] init] key:@"key_foo"];
+    BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper preferenceHelper];
+    Branch *branch = [[Branch alloc] initWithInterface:serverInterfaceMock queue:[[BNCServerRequestQueue alloc] init] cache:[[BNCLinkCache alloc] init] preferenceHelper:preferenceHelper key:@"key_foo"];
     [branch setAppListCheckEnabled:NO];
     
-    [BNCPreferenceHelper setCreditCount:1 forBucket:@"default"];
+    [preferenceHelper setCreditCount:1 forBucket:@"default"];
     
     BNCServerResponse *applyCodeResponse = [[BNCServerResponse alloc] init];
     applyCodeResponse.data = @{
@@ -555,7 +563,7 @@ NSInteger const  TEST_CREDITS = 30;
     __block BNCServerCallback applyCodeCallback;
     [[[serverInterfaceMock expect] andDo:^(NSInvocation *invocation) {
         applyCodeCallback(applyCodeResponse, nil);
-    }] postRequest:[OCMArg any] url:[BNCPreferenceHelper getAPIURL:@"apply-promo-code/LMDLDV"] key:[OCMArg any] callback:[OCMArg checkWithBlock:^BOOL(BNCServerCallback callback) {
+    }] postRequest:[OCMArg any] url:[preferenceHelper getAPIURL:@"apply-promo-code/LMDLDV"] key:[OCMArg any] callback:[OCMArg checkWithBlock:^BOOL(BNCServerCallback callback) {
         applyCodeCallback = callback;
         return YES;
     }]];
@@ -581,10 +589,11 @@ NSInteger const  TEST_CREDITS = 30;
     id serverInterfaceMock = OCMClassMock([BNCServerInterface class]);
     [self setupDefaultStubsForServerInterfaceMock:serverInterfaceMock];
     
-    Branch *branch = [[Branch alloc] initWithInterface:serverInterfaceMock queue:[[BNCServerRequestQueue alloc] init] cache:[[BNCLinkCache alloc] init] key:@"key_foo"];
+    BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper preferenceHelper];
+    Branch *branch = [[Branch alloc] initWithInterface:serverInterfaceMock queue:[[BNCServerRequestQueue alloc] init] cache:[[BNCLinkCache alloc] init] preferenceHelper:preferenceHelper key:@"key_foo"];
     [branch setAppListCheckEnabled:NO];
     
-    [BNCPreferenceHelper setCreditCount:1 forBucket:@"default"];
+    [preferenceHelper setCreditCount:1 forBucket:@"default"];
     
     BNCServerResponse *applyCodeResponse = [[BNCServerResponse alloc] init];
     applyCodeResponse.data = @{
@@ -610,7 +619,7 @@ NSInteger const  TEST_CREDITS = 30;
     __block BNCServerCallback applyCodeCallback;
     [[[serverInterfaceMock expect] andDo:^(NSInvocation *invocation) {
         applyCodeCallback(applyCodeResponse, nil);
-    }] postRequest:[OCMArg any] url:[BNCPreferenceHelper getAPIURL:@"applycode/LMDLDV"] key:[OCMArg any] callback:[OCMArg checkWithBlock:^BOOL(BNCServerCallback callback) {
+    }] postRequest:[OCMArg any] url:[preferenceHelper getAPIURL:@"applycode/LMDLDV"] key:[OCMArg any] callback:[OCMArg checkWithBlock:^BOOL(BNCServerCallback callback) {
         applyCodeCallback = callback;
         return YES;
     }]];
@@ -639,10 +648,11 @@ NSInteger const  TEST_CREDITS = 30;
     id serverInterfaceMock = OCMClassMock([BNCServerInterface class]);
     [self setupDefaultStubsForServerInterfaceMock:serverInterfaceMock];
     
-    Branch *branch = [[Branch alloc] initWithInterface:serverInterfaceMock queue:[[BNCServerRequestQueue alloc] init] cache:[[BNCLinkCache alloc] init] key:@"key_foo"];
+    BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper preferenceHelper];
+    Branch *branch = [[Branch alloc] initWithInterface:serverInterfaceMock queue:[[BNCServerRequestQueue alloc] init] cache:[[BNCLinkCache alloc] init] preferenceHelper:preferenceHelper key:@"key_foo"];
     [branch setAppListCheckEnabled:NO];
 
-    [BNCPreferenceHelper setCreditCount:1 forBucket:@"default"];
+    [preferenceHelper setCreditCount:1 forBucket:@"default"];
     
     BNCServerResponse *creditHistoryResponse = [[BNCServerResponse alloc] init];
     creditHistoryResponse.data = @[
@@ -662,7 +672,7 @@ NSInteger const  TEST_CREDITS = 30;
     __block BNCServerCallback creditHistoryCallback;
     [[[serverInterfaceMock expect] andDo:^(NSInvocation *invocation) {
         creditHistoryCallback(creditHistoryResponse, nil);
-    }] postRequest:[OCMArg any] url:[BNCPreferenceHelper getAPIURL:@"credithistory"] key:[OCMArg any] callback:[OCMArg checkWithBlock:^BOOL(BNCServerCallback callback) {
+    }] postRequest:[OCMArg any] url:[preferenceHelper getAPIURL:@"credithistory"] key:[OCMArg any] callback:[OCMArg checkWithBlock:^BOOL(BNCServerCallback callback) {
         creditHistoryCallback = callback;
         return YES;
     }]];

--- a/Branch-TestBed/Branch-SDK Load Tests/Branch_SDK_Load_Tests.m
+++ b/Branch-TestBed/Branch-SDK Load Tests/Branch_SDK_Load_Tests.m
@@ -21,10 +21,10 @@
 @implementation Branch_SDK_Load_Tests
 
 - (void)testLoad {
-    id preferenceHelperMock = OCMClassMock([BNCPreferenceHelper class]);
+    BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper preferenceHelper];
     id serverInterfaceMock = OCMClassMock([BNCServerInterface class]);
 
-    Branch *branch = [[Branch alloc] initWithInterface:serverInterfaceMock queue:[[BNCServerRequestQueue alloc] init] cache:[[BNCLinkCache alloc] init] key:@"key_foo"];
+    Branch *branch = [[Branch alloc] initWithInterface:serverInterfaceMock queue:[[BNCServerRequestQueue alloc] init] cache:[[BNCLinkCache alloc] init] preferenceHelper:preferenceHelper key:@"key_foo"];
     [branch setAppListCheckEnabled:NO];
     
     BNCServerResponse *linkResponse = [[BNCServerResponse alloc] init];
@@ -45,7 +45,7 @@
     __block BNCServerCallback urlCallback;
     [[[serverInterfaceMock stub] andDo:^(NSInvocation *invocation) {
         urlCallback(linkResponse, nil);
-    }] postRequest:[OCMArg any] url:[BNCPreferenceHelper getAPIURL:@"url"] key:[OCMArg any] callback:[OCMArg checkWithBlock:^BOOL(BNCServerCallback callback) {
+    }] postRequest:[OCMArg any] url:[preferenceHelper getAPIURL:@"url"] key:[OCMArg any] callback:[OCMArg checkWithBlock:^BOOL(BNCServerCallback callback) {
         urlCallback = callback;
         return YES;
     }]];
@@ -67,7 +67,7 @@
     [[[serverInterfaceMock expect] andDo:openOrInstallInvocation] postRequest:[OCMArg any] url:openOrInstallUrlCheckBlock key:[OCMArg any] callback:openOrInstallCallbackCheckBlock];
     
     // Fake branch key
-    [[[preferenceHelperMock stub] andReturn:@"foo"] getBranchKey:YES];
+    preferenceHelper.branchKey = @"foo";
     
     for (int i = 0; i < 1000; i++) {
         [branch getShortURLWithParams:nil andChannel:[NSString stringWithFormat:@"%d", i] andFeature:nil andCallback:^(NSString *url, NSError *error) {

--- a/Branch-TestBed/Branch-TestBed/AppDelegate.m
+++ b/Branch-TestBed/Branch-TestBed/AppDelegate.m
@@ -13,11 +13,8 @@
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
     Branch *branch = [Branch getInstance];
-//    [branch setDebug];
+    [branch setDebug];
     [branch initSessionWithLaunchOptions:launchOptions andRegisterDeepLinkHandler:^(NSDictionary *params, NSError *error) {
-        NSString *appDomain = [[NSBundle mainBundle] bundleIdentifier];
-        [[NSUserDefaults standardUserDefaults] removePersistentDomainForName:appDomain];
-
         if (!error) {
             NSLog(@"finished init with params = %@", [params description]);
         } else {

--- a/Branch-TestBed/Branch-TestBed/AppDelegate.m
+++ b/Branch-TestBed/Branch-TestBed/AppDelegate.m
@@ -13,8 +13,11 @@
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
     Branch *branch = [Branch getInstance];
-    [branch setDebug];
+//    [branch setDebug];
     [branch initSessionWithLaunchOptions:launchOptions andRegisterDeepLinkHandler:^(NSDictionary *params, NSError *error) {
+        NSString *appDomain = [[NSBundle mainBundle] bundleIdentifier];
+        [[NSUserDefaults standardUserDefaults] removePersistentDomainForName:appDomain];
+
         if (!error) {
             NSLog(@"finished init with params = %@", [params description]);
         } else {

--- a/Branch-TestBed/Branch-TestBed/ViewController.m
+++ b/Branch-TestBed/Branch-TestBed/ViewController.m
@@ -73,14 +73,7 @@
 }
 - (IBAction)cmdIdentifyUserClick:(id)sender {
     Branch *branch = [Branch getInstance];
-    [branch setIdentity:@"test_user_10" withCallback:^(NSDictionary *params, NSError *error) {
-        if (error) {
-            NSLog(@"err: %@", error);
-        }
-        else {
-            NSLog(@"updated");
-        }
-    }];
+    [branch setIdentity:@"test_user_10"];
 }
 - (IBAction)cmdClearUserClick:(id)sender {
     Branch *branch = [Branch getInstance];

--- a/Branch-TestBed/Branch-TestBed/ViewController.m
+++ b/Branch-TestBed/Branch-TestBed/ViewController.m
@@ -73,7 +73,14 @@
 }
 - (IBAction)cmdIdentifyUserClick:(id)sender {
     Branch *branch = [Branch getInstance];
-    [branch setIdentity:@"test_user_10"];
+    [branch setIdentity:@"test_user_10" withCallback:^(NSDictionary *params, NSError *error) {
+        if (error) {
+            NSLog(@"err: %@", error);
+        }
+        else {
+            NSLog(@"updated");
+        }
+    }];
 }
 - (IBAction)cmdClearUserClick:(id)sender {
     Branch *branch = [Branch getInstance];

--- a/Branch-TestBed/Podfile
+++ b/Branch-TestBed/Podfile
@@ -1,16 +1,7 @@
-target 'Branch-TestBed' do
-
-end
-
 target 'Branch-SDK Functionality Tests' do
   pod 'OCMock'
-  pod 'Nocilla', :inhibit_warnings => true
 end
 
 target 'Branch-SDK Load Tests' do
   pod 'OCMock'
-end
-
-target 'Branch-SDK UI Tests' do
-  pod 'Nocilla', :inhibit_warnings => true
 end

--- a/Branch-TestBed/Podfile.lock
+++ b/Branch-TestBed/Podfile.lock
@@ -1,13 +1,10 @@
 PODS:
-  - Nocilla (0.10.0)
   - OCMock (3.1.2)
 
 DEPENDENCIES:
-  - Nocilla
   - OCMock
 
 SPEC CHECKSUMS:
-  Nocilla: ae0a2b05f3087b473624ac2b25903695df51246a
   OCMock: a10ea9f0a6e921651f96f78b6faee95ebc813b92
 
 COCOAPODS: 0.36.4


### PR DESCRIPTION
@qinweigong 

A couple things here:

1. Moving away from a singleton for the PreferenceHelper (though this isn't really done, since they're all grabbing the global reference).
2. Making properties on the instance, so that they don't have to be reloaded from NSUserDefaults every time.