### PR TITLE
Delegate for activity item

### DIFF
--- a/Branch-SDK/Branch-SDK/BNCPreferenceHelper.m
+++ b/Branch-SDK/Branch-SDK/BNCPreferenceHelper.m
@@ -443,7 +443,7 @@ NSString * const BRANCH_PREFS_KEY_UNIQUE_BASE = @"bnc_unique_base_";
 
 - (void)persistPrefsToDisk {
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-        if (![NSKeyedArchiver archiveRootObject:self.persistenceDict toFile:[self prefsFile]]) {
+        if (![NSKeyedArchiver archiveRootObject:[self.persistenceDict copy] toFile:[self prefsFile]]) {
             NSLog(@"[Branch Warning] Failed to persist preferences to disk");
         }
     });

--- a/Branch-SDK/Branch-SDK/Branch.h
+++ b/Branch-SDK/Branch-SDK/Branch.h
@@ -163,13 +163,14 @@ typedef NS_ENUM(NSUInteger, BranchPromoCodeUsageType) {
 
 /**
  Create a BranchActivityItemProvider which subclasses the `UIActivityItemProvider` This can be used for simple sharing via a `UIActivityViewController`.
- 
+
  Internally, this will create a short Branch Url that will be attached to the shared content.
- 
+
  @param params A dictionary to use while building up the Branch link.
  @param feature The feature the generated link will be associated with.
- */
-+ (BranchActivityItemProvider *)getBranchActivityItemWithParams:(NSDictionary *)params andFeature:(NSString *)feature;
+*/
++ (BranchActivityItemProvider *)getBranchActivityItemWithParams:(NSDictionary *)params feature:(NSString *)feature;
++ (BranchActivityItemProvider *)getBranchActivityItemWithParams:(NSDictionary *)params andFeature:(NSString *)feature  __attribute__((deprecated(("Use methods without 'and'"))));
 
 /**
  Create a BranchActivityItemProvider which subclasses the `UIActivityItemProvider` This can be used for simple sharing via a `UIActivityViewController`.
@@ -180,7 +181,8 @@ typedef NS_ENUM(NSUInteger, BranchPromoCodeUsageType) {
  @param feature The feature the generated link will be associated with.
  @param stage The stage used for the generated link, typically used to indicate what part of a funnel the user is in.
  */
-+ (BranchActivityItemProvider *)getBranchActivityItemWithParams:(NSDictionary *)params andFeature:(NSString *)feature andStage:(NSString *)stage;
++ (BranchActivityItemProvider *)getBranchActivityItemWithParams:(NSDictionary *)params feature:(NSString *)feature stage:(NSString *)stage;
++ (BranchActivityItemProvider *)getBranchActivityItemWithParams:(NSDictionary *)params andFeature:(NSString *)feature andStage:(NSString *)stage __attribute__((deprecated(("Use methods without 'and'"))));
 
 /**
  Create a BranchActivityItemProvider which subclasses the `UIActivityItemProvider` This can be used for simple sharing via a `UIActivityViewController`.
@@ -192,7 +194,8 @@ typedef NS_ENUM(NSUInteger, BranchPromoCodeUsageType) {
  @param stage The stage used for the generated link, typically used to indicate what part of a funnel the user is in.
  @param tags An array of tag strings to be associated with the link.
  */
-+ (BranchActivityItemProvider *)getBranchActivityItemWithParams:(NSDictionary *)params andFeature:(NSString *)feature andStage:(NSString *)stage andTags:(NSArray *)tags;
++ (BranchActivityItemProvider *)getBranchActivityItemWithParams:(NSDictionary *)params feature:(NSString *)feature stage:(NSString *)stage tags:(NSArray *)tags;
++ (BranchActivityItemProvider *)getBranchActivityItemWithParams:(NSDictionary *)params andFeature:(NSString *)feature andStage:(NSString *)stage andTags:(NSArray *)tags __attribute__((deprecated(("Use methods without 'and'"))));
 
 /**
  Create a BranchActivityItemProvider which subclasses the `UIActivityItemProvider` This can be used for simple sharing via a `UIActivityViewController`.
@@ -205,7 +208,9 @@ typedef NS_ENUM(NSUInteger, BranchPromoCodeUsageType) {
  @param alias The alias for a link.
  @warning This can fail if the alias is already taken.
  */
-+ (BranchActivityItemProvider *)getBranchActivityItemWithParams:(NSDictionary *)params andFeature:(NSString *)feature andStage:(NSString *)stage andAlias:(NSString *)alias;
++ (BranchActivityItemProvider *)getBranchActivityItemWithParams:(NSDictionary *)params feature:(NSString *)feature stage:(NSString *)stage tags:(NSArray *)tags alias:(NSString *)alias;
++ (BranchActivityItemProvider *)getBranchActivityItemWithParams:(NSDictionary *)params andFeature:(NSString *)feature andStage:(NSString *)stage andAlias:(NSString *)alias __attribute__((deprecated(("Use methods without 'and'"))));
++ (BranchActivityItemProvider *)getBranchActivityItemWithParams:(NSDictionary *)params andTags:(NSArray *)tags andFeature:(NSString *)feature andStage:(NSString *)stage andAlias:(NSString *)alias __attribute__((deprecated(("Use methods without 'and'"))));
 
 /**
  Create a BranchActivityItemProvider which subclasses the `UIActivityItemProvider` This can be used for simple sharing via a `UIActivityViewController`.
@@ -213,13 +218,16 @@ typedef NS_ENUM(NSUInteger, BranchPromoCodeUsageType) {
  Internally, this will create a short Branch Url that will be attached to the shared content.
  
  @param params A dictionary to use while building up the Branch link.
- @param tags An array of tag strings to be associated with the link.
  @param feature The feature the generated link will be associated with.
  @param stage The stage used for the generated link, typically used to indicate what part of a funnel the user is in.
+ @param tags An array of tag strings to be associated with the link.
  @param alias The alias for a link.
+ @params delegate A delegate allowing you to override any of the parameters provided here based on the user-selected channel
  @warning This can fail if the alias is already taken.
  */
-+ (BranchActivityItemProvider *)getBranchActivityItemWithParams:(NSDictionary *)params andTags:(NSArray *)tags andFeature:(NSString *)feature andStage:(NSString *)stage andAlias:(NSString *)alias;
++ (BranchActivityItemProvider *)getBranchActivityItemWithParams:(NSDictionary *)params feature:(NSString *)feature stage:(NSString *)stage tags:(NSArray *)tags alias:(NSString *)alias delegate:(id <BranchActivityItemProviderDelegate>)delegate;
+
+
 
 #pragma mark - Initialization methods
 

--- a/Branch-SDK/Branch-SDK/Branch.m
+++ b/Branch-SDK/Branch-SDK/Branch.m
@@ -170,48 +170,49 @@ static int BNCDebugTriggerFingersSimulator = 2;
 
 #pragma mark - BrachActivityItemProvider methods
 
-+ (BranchActivityItemProvider *)getBranchActivityItemWithParams:(NSDictionary *)params
-                                                     andTags:(NSArray *)tags
-                                                  andFeature:(NSString *)feature
-                                                    andStage:(NSString *)stage
-                                                    andAlias:(NSString *)alias {
-    return [[BranchActivityItemProvider alloc] initWithParams:params andTags:tags andFeature:feature andStage:stage andAlias:alias];
-}
-
 + (BranchActivityItemProvider *)getBranchActivityItemWithParams:(NSDictionary *)params {
-    
-    return [[BranchActivityItemProvider alloc] initWithParams:params andTags:nil andFeature:nil andStage:nil andAlias:nil];
+    return [[BranchActivityItemProvider alloc] initWithParams:params tags:nil feature:nil stage:nil alias:nil delegate:nil];
 }
 
-+ (BranchActivityItemProvider *)getBranchActivityItemWithParams:(NSDictionary *)params
-                                                         andFeature:(NSString *)feature {
-    
-    return [[BranchActivityItemProvider alloc] initWithParams:params andTags:nil andFeature:feature andStage:nil andAlias:nil];
++ (BranchActivityItemProvider *)getBranchActivityItemWithParams:(NSDictionary *)params feature:(NSString *)feature {
+    return [[BranchActivityItemProvider alloc] initWithParams:params tags:nil feature:feature stage:nil alias:nil delegate:nil];
 }
 
-+ (BranchActivityItemProvider *)getBranchActivityItemWithParams:(NSDictionary *)params
-                                                         andFeature:(NSString *)feature
-                                                           andStage:(NSString *)stage {
-    
-    return [[BranchActivityItemProvider alloc] initWithParams:params andTags:nil andFeature:feature andStage:stage andAlias:nil];
++ (BranchActivityItemProvider *)getBranchActivityItemWithParams:(NSDictionary *)params feature:(NSString *)feature stage:(NSString *)stage {
+    return [[BranchActivityItemProvider alloc] initWithParams:params tags:nil feature:feature stage:stage alias:nil delegate:nil];
 }
 
-+ (BranchActivityItemProvider *)getBranchActivityItemWithParams:(NSDictionary *)params
-                                                         andFeature:(NSString *)feature
-                                                           andStage:(NSString *)stage
-                                                            andTags:(NSArray *)tags {
-    
-    return [[BranchActivityItemProvider alloc] initWithParams:params andTags:tags andFeature:feature andStage:stage andAlias:nil];
++ (BranchActivityItemProvider *)getBranchActivityItemWithParams:(NSDictionary *)params feature:(NSString *)feature stage:(NSString *)stage tags:(NSArray *)tags {
+    return [[BranchActivityItemProvider alloc] initWithParams:params tags:tags feature:feature stage:stage alias:nil delegate:nil];
 }
 
-+ (BranchActivityItemProvider *)getBranchActivityItemWithParams:(NSDictionary *)params
-                                                            andFeature:(NSString *)feature
-                                                           andStage:(NSString *)stage
-                                                           andAlias:(NSString *)alias {
-    
-    return [[BranchActivityItemProvider alloc] initWithParams:params andTags:nil andFeature:feature andStage:stage andAlias:alias];
++ (BranchActivityItemProvider *)getBranchActivityItemWithParams:(NSDictionary *)params feature:(NSString *)feature stage:(NSString *)stage tags:(NSArray *)tags alias:(NSString *)alias {
+    return [[BranchActivityItemProvider alloc] initWithParams:params tags:tags feature:feature stage:stage alias:alias delegate:nil];
 }
 
++ (BranchActivityItemProvider *)getBranchActivityItemWithParams:(NSDictionary *)params feature:(NSString *)feature stage:(NSString *)stage tags:(NSArray *)tags alias:(NSString *)alias delegate:(id <BranchActivityItemProviderDelegate>)delegate {
+    return [[BranchActivityItemProvider alloc] initWithParams:params tags:tags feature:feature stage:stage alias:alias delegate:delegate];
+}
+
++ (BranchActivityItemProvider *)getBranchActivityItemWithParams:(NSDictionary *)params andFeature:(NSString *)feature {
+    return [[BranchActivityItemProvider alloc] initWithParams:params tags:nil feature:feature stage:nil alias:nil delegate:nil];
+}
+
++ (BranchActivityItemProvider *)getBranchActivityItemWithParams:(NSDictionary *)params andFeature:(NSString *)feature andStage:(NSString *)stage {
+    return [[BranchActivityItemProvider alloc] initWithParams:params tags:nil feature:feature stage:stage alias:nil delegate:nil];
+}
+
++ (BranchActivityItemProvider *)getBranchActivityItemWithParams:(NSDictionary *)params andFeature:(NSString *)feature andStage:(NSString *)stage andTags:(NSArray *)tags {
+    return [[BranchActivityItemProvider alloc] initWithParams:params tags:tags feature:feature stage:stage alias:nil delegate:nil];
+}
+
++ (BranchActivityItemProvider *)getBranchActivityItemWithParams:(NSDictionary *)params andFeature:(NSString *)feature andStage:(NSString *)stage andAlias:(NSString *)alias {
+    return [[BranchActivityItemProvider alloc] initWithParams:params tags:nil feature:feature stage:stage alias:alias delegate:nil];
+}
+
++ (BranchActivityItemProvider *)getBranchActivityItemWithParams:(NSDictionary *)params andTags:(NSArray *)tags andFeature:(NSString *)feature andStage:(NSString *)stage andAlias:(NSString *)alias {
+    return [[BranchActivityItemProvider alloc] initWithParams:params tags:tags feature:feature stage:stage alias:alias delegate:nil];
+}
 
 #pragma mark - Configuration methods
 

--- a/Branch-SDK/Branch-SDK/BranchActivityItemProvider.h
+++ b/Branch-SDK/Branch-SDK/BranchActivityItemProvider.h
@@ -8,8 +8,27 @@
 
 #import <UIKit/UIKit.h>
 
+/**
+ The `BranchActivityItemProviderDelegate` allows you  to customize the link parameters based on the channel chosen by the user.
+ This is useful in the case that you want to add specific items only for Facebook or Twitter for instance.
+
+ Every item is optional, and if not provided, will fallback to the item provided with the constructor.
+ */
+@protocol BranchActivityItemProviderDelegate <NSObject>
+
+@optional
+- (NSDictionary *)activityItemParamsForChannel:(NSString *)channel;
+- (NSArray *)activityItemTagsForChannel:(NSString *)channel;
+- (NSString *)activityItemFeatureForChannel:(NSString *)channel;
+- (NSString *)activityItemStageForChannel:(NSString *)channel;
+- (NSString *)activityItemAliasForChannel:(NSString *)channel;
+- (NSString *)activityItemOverrideChannelForChannel:(NSString *)channel;
+
+@end
+
 @interface BranchActivityItemProvider : UIActivityItemProvider
 
-- (id)initWithParams:(NSDictionary *)params andTags:(NSArray *)tags andFeature:(NSString *)feature andStage:(NSString *)stage andAlias:(NSString *)alias;
+- (id)initWithParams:(NSDictionary *)params andTags:(NSArray *)tags andFeature:(NSString *)feature andStage:(NSString *)stage andAlias:(NSString *)alias  __attribute__((deprecated(("Use the delegate method instead"))));;
+- (id)initWithParams:(NSDictionary *)params tags:(NSArray *)tags feature:(NSString *)feature stage:(NSString *)stage alias:(NSString *)alias delegate:(id <BranchActivityItemProviderDelegate>)delegate;
 
 @end

--- a/Branch-SDK/Branch-SDK/BranchActivityItemProvider.m
+++ b/Branch-SDK/Branch-SDK/BranchActivityItemProvider.m
@@ -18,21 +18,27 @@
 @property (strong, nonatomic) NSString *stage;
 @property (strong, nonatomic) NSString *alias;
 @property (strong, nonatomic) NSString *userAgentString;
+@property (weak, nonatomic) id <BranchActivityItemProviderDelegate> delegate;
 
 @end
 
 @implementation BranchActivityItemProvider
 
 - (id)initWithParams:(NSDictionary *)params andTags:(NSArray *)tags andFeature:(NSString *)feature andStage:(NSString *)stage andAlias:(NSString *)alias {
+    return [self initWithParams:params tags:tags feature:feature stage:stage alias:alias delegate:nil];
+}
+
+- (id)initWithParams:(NSDictionary *)params tags:(NSArray *)tags feature:(NSString *)feature stage:(NSString *)stage alias:(NSString *)alias delegate:(id <BranchActivityItemProviderDelegate>)delegate {
     NSString *url = [[Branch getInstance] getLongURLWithParams:params andChannel:nil andTags:tags andFeature:feature andStage:stage andAlias:alias];
     
     if (self = [super initWithPlaceholderItem:[NSURL URLWithString:url]]) {
-        self.params = params;
-        self.tags = tags;
-        self.feature = feature;
-        self.stage = stage;
-        self.alias = alias;
-        self.userAgentString = [[[UIWebView alloc] init] stringByEvaluatingJavaScriptFromString:@"navigator.userAgent"];
+        _params = params;
+        _tags = tags;
+        _feature = feature;
+        _stage = stage;
+        _alias = alias;
+        _userAgentString = [[[UIWebView alloc] init] stringByEvaluatingJavaScriptFromString:@"navigator.userAgent"];
+        _delegate = delegate;
     }
     
     return self;
@@ -41,15 +47,28 @@
 - (id)item {
     NSString *channel = [BranchActivityItemProvider humanReadableChannelWithActivityType:self.activityType];
     
-    // Because Facebook immediately scrapes URLs, we add an additional parameter to the existing list, telling the backend to ignore the first click
-    if ([channel isEqualToString:@"facebook"] || [channel isEqualToString:@"twitter"]) {
-        return [NSURL URLWithString:[[Branch getInstance] getShortURLWithParams:self.params andTags:self.tags andChannel:channel andFeature:self.feature andStage:self.stage andAlias:self.alias ignoreUAString:self.userAgentString]];
+    // Allow for overrides specific to channel
+    NSDictionary *params = [self paramsForChannel:channel];
+    NSArray *tags = [self tagsForChannel:channel];
+    NSString *feature = [self featureForChannel:channel];
+    NSString *stage = [self stageForChannel:channel];
+    NSString *alias = [self aliasForChannel:channel];
+    
+    // Allow the channel param to be overridden, perhaps they want "fb" instead of "facebook"
+    if ([self.delegate respondsToSelector:@selector(activityItemOverrideChannelForChannel:)]) {
+        channel = [self.delegate activityItemOverrideChannelForChannel:channel];
     }
     
-    return [NSURL URLWithString:[[Branch getInstance] getShortURLWithParams:self.params andTags:self.tags andChannel:channel andFeature:self.feature andStage:self.stage andAlias:self.alias]];
+    // Because Facebook immediately scrapes URLs, we add an additional parameter to the existing list, telling the backend to ignore the first click
+    if ([channel isEqualToString:@"facebook"] || [channel isEqualToString:@"twitter"]) {
+        return [NSURL URLWithString:[[Branch getInstance] getShortURLWithParams:params andTags:tags andChannel:channel andFeature:feature andStage:stage andAlias:alias ignoreUAString:self.userAgentString]];
+    }
+    
+    return [NSURL URLWithString:[[Branch getInstance] getShortURLWithParams:params andTags:tags andChannel:channel andFeature:feature andStage:stage andAlias:alias]];
 }
 
-// Human readable activity type string
+#pragma mark - Internals
+
 + (NSString *)humanReadableChannelWithActivityType:(NSString *)activityString {
     NSString *channel = activityString; //default
     
@@ -86,6 +105,26 @@
         }
     }
     return channel;
+}
+
+- (NSDictionary *)paramsForChannel:(NSString *)channel {
+    return ([self.delegate respondsToSelector:@selector(activityItemParamsForChannel:)]) ? [self.delegate activityItemParamsForChannel:channel] : self.params;
+}
+
+- (NSArray *)tagsForChannel:(NSString *)channel {
+    return ([self.delegate respondsToSelector:@selector(activityItemTagsForChannel:)]) ? [self.delegate activityItemTagsForChannel:channel] : self.tags;
+}
+
+- (NSString *)featureForChannel:(NSString *)channel {
+    return ([self.delegate respondsToSelector:@selector(activityItemFeatureForChannel:)]) ? [self.delegate activityItemFeatureForChannel:channel] : self.feature;
+}
+
+- (NSString *)stageForChannel:(NSString *)channel {
+    return ([self.delegate respondsToSelector:@selector(activityItemStageForChannel:)]) ? [self.delegate activityItemStageForChannel:channel] : self.stage;
+}
+
+- (NSString *)aliasForChannel:(NSString *)channel {
+    return ([self.delegate respondsToSelector:@selector(activityItemAliasForChannel:)]) ? [self.delegate activityItemAliasForChannel:channel] : self.alias;
 }
 
 @end

--- a/README.md
+++ b/README.md
@@ -536,7 +536,9 @@ UIActivityView is the standard way of allowing users to share content from your 
 
 The Branch iOS SDK includes a subclassed UIActivityItemProvider that can be passed into a UIActivityViewController, that will generate a Branch short URL and automatically tag it with the channel the user selects (Facebook, Twitter, etc.).
 
-**Note**: This method was formerly getBranchActivityItemWithDefaultURL:, which is now deprecated. Rather than requiring a default URL that acts as a placeholder for UIActivityItemProvider, a longURL is generated instantly and synchronously.
+You can optionally provide a delegate that conforms to the `BranchActivityItemProviderDelegate` which allows you to customize the content of the short url actually used to shared depending on which platform the user has chosen to share with.
+
+As [mentioned in the docs](https://dev.branch.io/recipes/dynamic_link_creation/#parameters-1), you can customize generated links to provide an `$og_image_url` if the user is posting to Facebook, or `twitter:image` if the user chose Twitter, for example.
 
 The sample app included with the Branch iOS SDK shows a sample of this in ViewController.m:
 


### PR DESCRIPTION
@qinweigong @francisjervis

This pull request adds the ability for devs to change the items used to create the short url based on the channel the user chooses.

Additionally, this allows the dev to override the "human readable channel" that Branch automatically uses (for instance, you could use "fb" instead of "facebook" or something like that).

It also re-organizes the Branch interface so the ordering is more logical.

```
- (id)foo;
- (id)foo:bar;
- (id)foo:bar:baz;
```

Instead of

```
- (id)foo;
- (id)foo:baz:bar;
- (id)foo:bar;
```