### PR TITLE
Fixing bad key used for object removal.

### DIFF
--- a/Branch-SDK/Branch-SDK/BranchCreditHistoryRequest.m
+++ b/Branch-SDK/Branch-SDK/BranchCreditHistoryRequest.m
@@ -64,7 +64,7 @@
     
     for (NSMutableDictionary *transaction in response.data) {
         if (transaction[@"referrer"] == [NSNull null]) {
-            [transaction removeObjectForKey:transaction[@"referrer"]];
+            [transaction removeObjectForKey:@"referrer"];
         }
         if (transaction[@"referree"] == [NSNull null]) {
             [transaction removeObjectForKey:@"referree"];


### PR DESCRIPTION
@aaustin 

Fixed this once before, but must have been lost in a merge. This is what actually caused the bug in the Invite SDK. I'll probably go through and revert those checks in that SDK, as they will be redundant.