### PR TITLE
Identity Type Mixup

### DIFF
--- a/Branch-SDK/Branch-SDK/BNCPreferenceHelper.m
+++ b/Branch-SDK/Branch-SDK/BNCPreferenceHelper.m
@@ -473,7 +473,12 @@ NSString * const BRANCH_PREFS_KEY_UNIQUE_BASE = @"bnc_unique_base_";
 }
 
 - (NSString *)readStringFromDefaults:(NSString *)key {
-    NSString *str = self.persistenceDict[key];
+    id str = self.persistenceDict[key];
+    
+    if ([str isKindOfClass:[NSNumber class]]) {
+        str = [str stringValue];
+    }
+    
     return str;
 }
 

--- a/Branch-SDK/Branch-SDK/BranchOpenRequest.m
+++ b/Branch-SDK/Branch-SDK/BranchOpenRequest.m
@@ -80,9 +80,16 @@
     BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper preferenceHelper];
 
     NSDictionary *data = response.data;
+
+    // Handle possibly mis-parsed identity.
+    id userIdentity = data[@"identity"];
+    if ([userIdentity isKindOfClass:[NSNumber class]]) {
+        userIdentity = [userIdentity stringValue];
+    }
+    
     preferenceHelper.deviceFingerprintID = data[@"device_fingerprint_id"];
     preferenceHelper.userUrl = data[@"link"];
-    preferenceHelper.userIdentity = data[@"identity"];
+    preferenceHelper.userIdentity = userIdentity;
     preferenceHelper.sessionID = data[@"session_id"];
     [BNCSystemObserver setUpdateState];
     


### PR DESCRIPTION
@aaustin 
Because the JSON parser is naive to what types it's getting back, it seems there are cases where they identity can become a number.
To avoid this, we are now checking on both the set/get sides to ensure the type we expect comes through.